### PR TITLE
Upload files under uploads directory after command succeed

### DIFF
--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -39,10 +39,8 @@ module Magellan
           Dir.mktmpdir 'workspace' do |dir|
             dfiles = parse(msg.attributes['download_files'])
             logger.info("dfiles: #{dfiles}")
-            ufiles =  parse(msg.attributes['upload_files'])
-            logger.info("ufiles: #{ufiles}")
 
-            context = Context.new(dir, dfiles, ufiles)
+            context = Context.new(dir, dfiles)
             context.setup
             logger.info("context.setup done.")
 

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -11,19 +11,18 @@ module Magellan
       class Context
         include Log
 
-        attr_reader :workspace, :remote_download_files, :remote_upload_files
-        def initialize(workspace, remote_download_files, remote_upload_files)
+        attr_reader :workspace, :remote_download_files
+        def initialize(workspace, remote_download_files)
           @workspace = workspace
           @remote_download_files = remote_download_files
-          @remote_upload_files = remote_upload_files
         end
 
         KEYS = [
           :workspace,
           :downloads_dir, :uploads_dir,
-          :download_files, :upload_files,
-          :local_download_files, :local_upload_files,
-          :remote_download_files, :remote_upload_files
+          :download_files,
+          :local_download_files,
+          :remote_download_files,
         ].freeze
 
         def [](key)
@@ -53,15 +52,6 @@ module Magellan
         def uploads_dir
           File.join(workspace, 'uploads')
         end
-
-        def upload_mapping
-          @upload_mapping ||= build_mapping(uploads_dir, remote_upload_files)
-        end
-
-        def local_upload_files
-          @local_upload_files ||= build_local_files_obj(remote_upload_files, upload_mapping)
-        end
-        alias_method :upload_files, :local_upload_files
 
         def setup
           setup_dirs

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -71,12 +71,15 @@ module Magellan
         end
 
         def upload
-          upload_mapping.each do |url, path|
-            logger.info("Uploading: #{path} to #{url}")
-            uri = parse_uri(url)
-            bucket = GCP.storage.bucket(uri.host)
-            bucket.create_file path, uri.path.sub(/\A\//, '')
-            logger.info("Upload OK: #{path} to #{url}")
+          Dir.chdir(uploads_dir) do
+            Dir.glob('**/*') do |path|
+              next if File.directory?(path)
+              url = "gs://#{@last_bucket_name}/#{path}"
+              logger.info("Uploading: #{path} to #{url}")
+              bucket = GCP.storage.bucket(@last_bucket_name)
+              bucket.create_file path, path
+              logger.info("Upload OK: #{path} to #{url}")
+            end
           end
         end
 

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -62,7 +62,8 @@ module Magellan
             FileUtils.mkdir_p File.dirname(path)
             logger.debug("Downloading: #{url} to #{path}")
             uri = parse_uri(url)
-            bucket = GCP.storage.bucket(uri.host)
+            @last_bucket_name = uri.host
+            bucket = GCP.storage.bucket(@last_bucket_name)
             file = bucket.file uri.path.sub(/\A\//, '')
             file.download(path)
             logger.info("Download OK: #{url} to #{path}")


### PR DESCRIPTION
Upload files under uploads directory after command succeed.

~~This PR depends on #3 , check the actual differences [here](https://github.com/groovenauts/magellan-gcs-proxy/compare/f1af560...features/upload_files_under_uploads_directory)~~

## Bucket name to upload

Use bucket name of last download URL to upload because of removing upload_files.

## Reviewers

- [x] @nagachika 
- [x] @yodack 
