### PR TITLE
Use simplecov and rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ Style/Documentation:
 LineLength:
   Max: 130
 
+Metrics/AbcSize:
+  Max: 20
+
 Metrics/MethodLength:
   Max: 15
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,5 @@ Metrics/MethodLength:
 Lint/AssignmentInCondition:
   Enabled: false
 
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ LineLength:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/CyclomaticComplexity:
+  Max: 8
+
 Metrics/MethodLength:
   Max: 15
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+Style/Documentation:
+  Enabled: false
+
+LineLength:
+  Max: 130
+
+Metrics/MethodLength:
+  Max: 15
+
+Lint/AssignmentInCondition:
+  Enabled: false
+

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
+  gem 'simplecov'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :development do
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
   gem 'simplecov'
+  gem 'rubocop', '~> 0.44.1', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,8 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task(:default).clear
+task default: [:rubocop, :spec]

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "magellan/gcs/proxy"
+require 'bundler/setup'
+require 'magellan/gcs/proxy'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "magellan/gcs/proxy"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -5,7 +5,7 @@ gem 'magellan-gcs-proxy'
 
 group :development do
   gem 'brocket'
-  gem "pry"
+  gem 'pry'
   gem 'pry-byebug'
   gem 'pry-stack_explorer'
 end

--- a/exe/magellan-gcs-proxy
+++ b/exe/magellan-gcs-proxy
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 Magellan::Gcs::Proxy::Cli.new(*ARGV).run

--- a/exe/magellan-gcs-proxy-dev-progress-listener
+++ b/exe/magellan-gcs-proxy-dev-progress-listener
@@ -7,7 +7,8 @@ subname = ARGV.first
 puts "Listening to #{subname}"
 Magellan::Gcs::Proxy::GCP.pubsub.subscription(subname).tap do |sub|
   sub.listen do |msg|
-    puts (msg.attributes.map { |k, v| "#{k}:#{v}" } + [msg.data]).join("\t")
+    attrs = { 'data' => msg.data }.update(msg.attributes)
+    puts attrs.map { |k, v| "#{k}:#{v}" }.join("\t")
     msg.ack!
   end
 end

--- a/exe/magellan-gcs-proxy-dev-progress-listener
+++ b/exe/magellan-gcs-proxy-dev-progress-listener
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 require 'json'
 
 subname = ARGV.first
 puts "Listening to #{subname}"
 Magellan::Gcs::Proxy::GCP.pubsub.subscription(subname).tap do |sub|
   sub.listen do |msg|
-    puts (msg.attributes.map{|k,v| "#{k}:#{v}"} + [msg.data]).join("\t")
+    puts (msg.attributes.map { |k, v| "#{k}:#{v}" } + [msg.data]).join("\t")
     msg.ack!
   end
 end

--- a/lib/magellan/gcs/proxy.rb
+++ b/lib/magellan/gcs/proxy.rb
@@ -1,7 +1,7 @@
 require 'dotenv'
 Dotenv.load
 
-require "magellan/gcs/proxy/version"
+require 'magellan/gcs/proxy/version'
 require 'magellan/gcs/proxy/expand_variable'
 require 'magellan/gcs/proxy/config'
 require 'magellan/gcs/proxy/log'
@@ -19,13 +19,11 @@ require 'magellan/gcs/proxy/cli'
 module Magellan
   module Gcs
     module Proxy
-
       class << self
         def config
           @config ||= Config.new
         end
       end
-
     end
   end
 end

--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -39,13 +39,13 @@ module Magellan
           context = Context.new(msg)
           context.notify(1, TOTAL, "Processing message: #{msg.inspect}")
           context.setup do
-            context.process_with_notification(2, 3, 4, TOTAL, 'Download', &:download)
+            context.process_with_notification([2, 3, 4], TOTAL, 'Download', &:download)
 
             cmd = build_command(context)
 
             exec = ->(*) { LoggerPipe.run(logger, cmd, returns: :none, logging: :both) }
-            context.process_with_notification(5, 6, 7, TOTAL, 'Command', exec) do
-              context.process_with_notification(8, 9, 10, TOTAL, 'Upload', &:upload)
+            context.process_with_notification([5, 6, 7], TOTAL, 'Command', exec) do
+              context.process_with_notification([8, 9, 10], TOTAL, 'Upload', &:upload)
 
               msg.acknowledge!
               context.notify(11, TOTAL, 'Acknowledged')

--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -41,7 +41,7 @@ module Magellan
           context.setup do
             context.process_with_notification(2, 3, 4, TOTAL, 'Download', &:download)
 
-            cmd = build_command(msg, context)
+            cmd = build_command(context)
 
             exec = ->(*) { LoggerPipe.run(logger, cmd, returns: :none, logging: :both) }
             context.process_with_notification(5, 6, 7, TOTAL, 'Command', exec) do
@@ -54,8 +54,8 @@ module Magellan
           context.notify(12, TOTAL, 'Cleanup')
         end
 
-        def build_command(msg, context)
-          msg_wrapper = MessageWrapper.new(msg, context)
+        def build_command(context)
+          msg_wrapper = MessageWrapper.new(context)
           ExpandVariable.expand_variables(cmd_template, msg_wrapper)
         end
       end

--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -1,5 +1,5 @@
-require "magellan/gcs/proxy"
-require "magellan/gcs/proxy/log"
+require 'magellan/gcs/proxy'
+require 'magellan/gcs/proxy/log'
 
 require 'json'
 require 'logger'
@@ -18,7 +18,7 @@ module Magellan
         end
 
         def run
-          logger.info("Start listening")
+          logger.info('Start listening')
           GCP.subscription.listen do |msg|
             begin
               process(msg)
@@ -43,24 +43,21 @@ module Magellan
 
             cmd = build_command(msg, context)
 
-            exec = ->(*){ LoggerPipe.run(logger, cmd, returns: :none, logging: :both) }
+            exec = ->(*) { LoggerPipe.run(logger, cmd, returns: :none, logging: :both) }
             context.process_with_notification(5, 6, 7, TOTAL, 'Command', exec) do
-
               context.process_with_notification(8, 9, 10, TOTAL, 'Upload', &:upload)
 
               msg.acknowledge!
-              context.notify(11, TOTAL, "Acknowledged")
-
+              context.notify(11, TOTAL, 'Acknowledged')
             end
           end
-          context.notify(12, TOTAL, "Cleanup")
+          context.notify(12, TOTAL, 'Cleanup')
         end
 
         def build_command(msg, context)
           msg_wrapper = MessageWrapper.new(msg, context)
           ExpandVariable.expand_variables(cmd_template, msg_wrapper)
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -20,16 +20,18 @@ module Magellan
         def run
           logger.info('Start listening')
           GCP.subscription.listen do |msg|
-            begin
-              process(msg)
-            rescue => e
-              logger.error("[#{e.class.name}] #{e.message}")
-              verbose("Backtrace\n  " << e.backtrace.join("\n  "))
-            end
+            process_with_error_handling(msg)
           end
         rescue => e
           logger.error("[#{e.class.name}] #{e.message}")
           raise e
+        end
+
+        def process_with_error_handling(msg)
+          process(msg)
+        rescue => e
+          logger.error("[#{e.class.name}] #{e.message}")
+          verbose("Backtrace\n  " << e.backtrace.join("\n  "))
         end
 
         TOTAL = 12

--- a/lib/magellan/gcs/proxy/cli.rb
+++ b/lib/magellan/gcs/proxy/cli.rb
@@ -24,9 +24,7 @@ module Magellan
               process(msg)
             rescue => e
               logger.error("[#{e.class.name}] #{e.message}")
-              if ENV['VERBOSE'] =~ /true|yes|on|1/i
-                logger.debug("Backtrace\n  " << e.backtrace.join("\n  "))
-              end
+              verbose("Backtrace\n  " << e.backtrace.join("\n  "))
             end
           end
         rescue => e

--- a/lib/magellan/gcs/proxy/composite_logger.rb
+++ b/lib/magellan/gcs/proxy/composite_logger.rb
@@ -1,4 +1,4 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 module Magellan
   module Gcs
@@ -31,7 +31,6 @@ module Magellan
             end
           INSTANCE_METHODS
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/config.rb
+++ b/lib/magellan/gcs/proxy/config.rb
@@ -8,7 +8,6 @@ module Magellan
   module Gcs
     module Proxy
       class Config
-
         attr_reader :path
         def initialize(path = './config.yml')
           @path = path
@@ -22,16 +21,15 @@ module Magellan
           erb = ERB.new(File.read(path), nil, '-')
           erb.filename = path
           t = erb.result
-          puts "=" * 100
+          puts '=' * 100
           puts t
-          puts "-" * 100
+          puts '-' * 100
           YAML.load(t)
         end
 
         def [](key)
           data[key.to_s]
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/config.rb
+++ b/lib/magellan/gcs/proxy/config.rb
@@ -30,6 +30,10 @@ module Magellan
         def [](key)
           data[key.to_s]
         end
+
+        def verbose?
+          ENV['VERBOSE'] =~ /true|yes|on|1/i
+        end
       end
     end
   end

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
-require "magellan/gcs/proxy"
-require "magellan/gcs/proxy/log"
+require 'magellan/gcs/proxy'
+require 'magellan/gcs/proxy/log'
 
 require 'fileutils'
 require 'uri'
@@ -41,11 +41,11 @@ module Magellan
         end
 
         def notify(progress, total, data, severity: :info)
-          notifier.notify(severity, message, data, {progress: progress, total: total})
+          notifier.notify(severity, message, data, progress: progress, total: total)
         end
 
         def ltsv(hash)
-          hash.map{|k,v| "#{k}:#{v}"}.join("\t")
+          hash.map { |k, v| "#{k}:#{v}" }.join("\t")
         end
 
         KEYS = [
@@ -53,13 +53,12 @@ module Magellan
           :downloads_dir, :uploads_dir,
           :download_files,
           :local_download_files,
-          :remote_download_files,
+          :remote_download_files
         ].freeze
 
         def [](key)
           case key.to_sym
           when *KEYS then send(key)
-          else nil
           end
         end
 
@@ -78,7 +77,7 @@ module Magellan
         def local_download_files
           @local_download_files ||= build_local_files_obj(remote_download_files, download_mapping)
         end
-        alias_method :download_files, :local_download_files
+        alias download_files local_download_files
 
         def uploads_dir
           File.join(workspace, 'uploads')
@@ -115,7 +114,7 @@ module Magellan
         end
 
         def setup_dirs
-          [:downloads_dir, :uploads_dir].each{|k| FileUtils.mkdir_p(send(k))}
+          [:downloads_dir, :uploads_dir].each { |k| FileUtils.mkdir_p(send(k)) }
         end
 
         def build_mapping(base_dir, obj)
@@ -129,7 +128,7 @@ module Magellan
           case obj
           when nil then []
           when Hash then flatten_values(obj.values)
-          when Array then obj.map{|i| flatten_values(i) }
+          when Array then obj.map { |i| flatten_values(i) }
           else obj
           end
         end
@@ -147,13 +146,12 @@ module Magellan
 
         def build_local_files_obj(obj, mapping)
           case obj
-          when Hash then obj.each_with_object({}){|(k,v), d| d[k] = build_local_files_obj(v, mapping)}
-          when Array then obj.map{|i| build_local_files_obj(i, mapping)}
+          when Hash then obj.each_with_object({}) { |(k, v), d| d[k] = build_local_files_obj(v, mapping) }
+          when Array then obj.map { |i| build_local_files_obj(i, mapping) }
           when String then mapping[obj]
           else obj
           end
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -27,23 +27,6 @@ module Magellan
           end
         end
 
-        def process_with_notification(start_no, complete_no, error_no, total, base_message, main = nil)
-          notify(start_no, total, "#{base_message} starting")
-          begin
-            main ? main.call(self) : yield(self)
-          rescue => e
-            notify(error_no, total, "#{base_message} error: [#{e.class}] #{e.message}", severity: :error)
-            raise e unless main
-          else
-            notify(complete_no, total, "#{base_message} completed")
-            yield(self) if main
-          end
-        end
-
-        def notify(progress, total, data, severity: :info)
-          notifier.notify(severity, message, data, progress: progress, total: total)
-        end
-
         def ltsv(hash)
           hash.map { |k, v| "#{k}:#{v}" }.join("\t")
         end

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -31,24 +31,6 @@ module Magellan
           hash.map { |k, v| "#{k}:#{v}" }.join("\t")
         end
 
-        KEYS = [
-          :workspace,
-          :downloads_dir, :uploads_dir,
-          :download_files,
-          :local_download_files,
-          :remote_download_files
-        ].freeze
-
-        def [](key)
-          case key.to_sym
-          when *KEYS then send(key)
-          end
-        end
-
-        def include?(key)
-          KEYS.include?(key)
-        end
-
         def downloads_dir
           File.join(workspace, 'downloads')
         end

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -55,7 +55,7 @@ module Magellan
             uri = parse_uri(url)
             @last_bucket_name = uri.host
             bucket = GCP.storage.bucket(@last_bucket_name)
-            file = bucket.file uri.path.sub(/\A\//, '')
+            file = bucket.file uri.path.sub(%r{\A/}, '')
             file.download(path)
             logger.info("Download OK: #{url} to #{path}")
           end

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -1,17 +1,16 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 module Magellan
   module Gcs
     module Proxy
       module ExpandVariable
-
         class InvalidReferenceError < StandardError
         end
 
         module_function
 
         def dig_variables(variable_ref, data)
-          vars = variable_ref.split(".").map{|i| (/\A\d+\z/.match(i)) ? i.to_i : i }
+          vars = variable_ref.split('.').map { |i| /\A\d+\z/.match(i) ? i.to_i : i }
           value = vars.inject(data) do |tmp, v|
             case v
             when String
@@ -41,13 +40,13 @@ module Magellan
 
         def expand_variables(str, data, quote_string: false)
           data ||= {}
-          str.gsub(/\%\{\s*([\w.]+)\s*\}/) do |m|
+          str.gsub(/\%\{\s*([\w.]+)\s*\}/) do |_m|
             var = Regexp.last_match(1)
             value =
               begin
                 dig_variables(var, data)
               rescue InvalidReferenceError
-                ""
+                ''
               end
 
             case value
@@ -58,7 +57,6 @@ module Magellan
           end
         end
       end
-
     end
   end
 end

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -17,29 +17,29 @@ module Magellan
         end
 
         def dig_variable(tmp, v, variable_ref)
-            case v
-            when String
-              if tmp.respond_to?(:[]) && tmp.respond_to?(:include?)
-                if tmp.include?(v)
-                  tmp[v]
-                else
-                  raise InvalidReferenceError, variable_ref
-                end
+          case v
+          when String
+            if tmp.respond_to?(:[]) && tmp.respond_to?(:include?)
+              if tmp.include?(v)
+                tmp[v]
               else
                 raise InvalidReferenceError, variable_ref
               end
-            when Integer
-              case tmp
-              when Array
-                if tmp.size > v
-                  tmp[v]
-                else
-                  raise InvalidReferenceError, variable_ref
-                end
-              else
-                raise InvalidReferenceError, variable_ref
-              end
+            else
+              raise InvalidReferenceError, variable_ref
             end
+          when Integer
+            case tmp
+            when Array
+              if tmp.size > v
+                tmp[v]
+              else
+                raise InvalidReferenceError, variable_ref
+              end
+            else
+              raise InvalidReferenceError, variable_ref
+            end
+          end
         end
 
         def expand_variables(str, data, quote_string: false)

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -12,6 +12,11 @@ module Magellan
         def dig_variables(variable_ref, data)
           vars = variable_ref.split('.').map { |i| /\A\d+\z/ =~ i ? i.to_i : i }
           value = vars.inject(data) do |tmp, v|
+            dig_variable(tmp, v, variable_ref)
+          end
+        end
+
+        def dig_variable(tmp, v, variable_ref)
             case v
             when String
               if tmp.respond_to?(:[]) && tmp.respond_to?(:include?)
@@ -35,7 +40,6 @@ module Magellan
                 raise InvalidReferenceError, variable_ref
               end
             end
-          end
         end
 
         def expand_variables(str, data, quote_string: false)

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -10,7 +10,7 @@ module Magellan
         module_function
 
         def dig_variables(variable_ref, data)
-          vars = variable_ref.split('.').map { |i| /\A\d+\z/.match(i) ? i.to_i : i }
+          vars = variable_ref.split('.').map { |i| /\A\d+\z/ =~ i ? i.to_i : i }
           value = vars.inject(data) do |tmp, v|
             case v
             when String

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -20,26 +20,15 @@ module Magellan
           case v
           when String
             if tmp.respond_to?(:[]) && tmp.respond_to?(:include?)
-              if tmp.include?(v)
-                tmp[v]
-              else
-                raise InvalidReferenceError, variable_ref
-              end
-            else
-              raise InvalidReferenceError, variable_ref
+              return tmp[v] if tmp.include?(v)
             end
           when Integer
             case tmp
             when Array
-              if tmp.size > v
-                tmp[v]
-              else
-                raise InvalidReferenceError, variable_ref
-              end
-            else
-              raise InvalidReferenceError, variable_ref
+              return tmp[v] if tmp.size > v
             end
           end
+          raise InvalidReferenceError, variable_ref
         end
 
         def expand_variables(str, data, quote_string: false)

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -11,7 +11,7 @@ module Magellan
 
         def dig_variables(variable_ref, data)
           vars = variable_ref.split('.').map { |i| /\A\d+\z/ =~ i ? i.to_i : i }
-          value = vars.inject(data) do |tmp, v|
+          vars.inject(data) do |tmp, v|
             dig_variable(tmp, v, variable_ref)
           end
         end

--- a/lib/magellan/gcs/proxy/gcp.rb
+++ b/lib/magellan/gcs/proxy/gcp.rb
@@ -3,8 +3,8 @@ require 'magellan/gcs/proxy'
 
 require 'google/cloud/logging'
 require 'google/cloud/logging/version'
-require "google/cloud/pubsub"
-require "google/cloud/storage"
+require 'google/cloud/pubsub'
+require 'google/cloud/storage'
 require 'net/http'
 
 module Magellan
@@ -26,7 +26,7 @@ module Magellan
 
         METADATA_HOST = 'metadata.google.internal'.freeze
         METADATA_PATH_BASE = '/computeMetadata/v1/'.freeze
-        METADATA_HEADER = {"Metadata-Flavor" => "Google"}.freeze
+        METADATA_HEADER = { 'Metadata-Flavor' => 'Google' }.freeze
 
         def retrieve_metadata(key)
           http = Net::HTTP.new(METADATA_HOST)
@@ -58,7 +58,7 @@ module Magellan
         end
 
         def reset
-          instance_variables.each {|ivar| instance_variable_set(ivar, nil)}
+          instance_variables.each { |ivar| instance_variable_set(ivar, nil) }
         end
       end
     end

--- a/lib/magellan/gcs/proxy/log.rb
+++ b/lib/magellan/gcs/proxy/log.rb
@@ -7,6 +7,10 @@ module Magellan
       module Log
         module_function
 
+        def verbose(msg)
+          logger.debug(msg) if GCP.config.verbose?
+        end
+
         def logger
           @logger ||= build_logger(loggers)
         end

--- a/lib/magellan/gcs/proxy/log.rb
+++ b/lib/magellan/gcs/proxy/log.rb
@@ -47,7 +47,7 @@ module Magellan
           :instance_id,
           :pod_id,
           :container_name,
-          :zone
+          :zone,
         ].freeze
 
         def build_cloud_logging_logger(config)

--- a/lib/magellan/gcs/proxy/log.rb
+++ b/lib/magellan/gcs/proxy/log.rb
@@ -38,12 +38,12 @@ module Magellan
 
         CLOUD_LOGGING_RESOURCE_KEYS = [
           :project_id,
-					:cluster_name,
-					:namespace_id,
-					:instance_id,
-					:pod_id,
-					:container_name,
-					:zone,
+          :cluster_name,
+          :namespace_id,
+          :instance_id,
+          :pod_id,
+          :container_name,
+          :zone
         ].freeze
 
         def build_cloud_logging_logger(config)
@@ -64,9 +64,9 @@ module Magellan
               d[key] = v
             end
           end
-          resource = GCP.logging.resource "container", options
+          resource = GCP.logging.resource 'container', options
           Google::Cloud::Logging::Logger.new GCP.logging, log_name, resource,
-                                             {magellan_gcs_proxy: Magellan::Gcs::Proxy::VERSION}
+                                             magellan_gcs_proxy: Magellan::Gcs::Proxy::VERSION
         end
       end
     end

--- a/lib/magellan/gcs/proxy/message_wrapper.rb
+++ b/lib/magellan/gcs/proxy/message_wrapper.rb
@@ -7,7 +7,7 @@ module Magellan
         attr_reader :msg, :context
         def initialize(context)
           @msg = context.message
-          @context = context
+          @context = ContextAccessor.new(context)
         end
 
         def [](key)
@@ -25,6 +25,31 @@ module Magellan
 
         def attributes
           Attrs.new(msg.attributes)
+        end
+
+        class ContextAccessor
+          attr_accessor :context
+          def initialize(context)
+            @context = context
+          end
+
+          KEYS = [
+            :workspace,
+            :downloads_dir, :uploads_dir,
+            :download_files,
+            :local_download_files,
+            :remote_download_files
+          ].freeze
+
+          def [](key)
+            case key.to_sym
+            when *KEYS then context.send(key)
+            end
+          end
+
+          def include?(key)
+            KEYS.include?(key)
+          end
         end
 
         class Attrs

--- a/lib/magellan/gcs/proxy/message_wrapper.rb
+++ b/lib/magellan/gcs/proxy/message_wrapper.rb
@@ -1,4 +1,4 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 module Magellan
   module Gcs
@@ -6,7 +6,8 @@ module Magellan
       class MessageWrapper
         attr_reader :msg, :context
         def initialize(msg, context)
-          @msg, @context = msg, context
+          @msg = msg
+          @context = context
         end
 
         def [](key)
@@ -35,7 +36,11 @@ module Magellan
           def [](key)
             value = data[key]
             if value.is_a?(String) && value =~ /\A\[.*\]\z|\A\{.*\}\z/
-              JSON.parse(value) rescue value
+              begin
+                JSON.parse(value)
+              rescue
+                value
+              end
             else
               value
             end
@@ -44,7 +49,6 @@ module Magellan
           def include?(key)
             data.include?(key) || data.include?(key.to_sym)
           end
-
         end
       end
     end

--- a/lib/magellan/gcs/proxy/message_wrapper.rb
+++ b/lib/magellan/gcs/proxy/message_wrapper.rb
@@ -5,8 +5,8 @@ module Magellan
     module Proxy
       class MessageWrapper
         attr_reader :msg, :context
-        def initialize(msg, context)
-          @msg = msg
+        def initialize(context)
+          @msg = context.message
           @context = context
         end
 

--- a/lib/magellan/gcs/proxy/progress_notification.rb
+++ b/lib/magellan/gcs/proxy/progress_notification.rb
@@ -6,7 +6,8 @@ module Magellan
       module ProgressNotification
         include Log
 
-        def process_with_notification(start_no, complete_no, error_no, total, base_message, main = nil)
+        def process_with_notification(numbers, total, base_message, main = nil)
+          start_no, complete_no, error_no = *numbers
           notify(start_no, total, "#{base_message} starting")
           begin
             main ? main.call(self) : yield(self)

--- a/lib/magellan/gcs/proxy/progress_notification.rb
+++ b/lib/magellan/gcs/proxy/progress_notification.rb
@@ -1,4 +1,4 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 module Magellan
   module Gcs
@@ -49,7 +49,6 @@ module Magellan
             end
           end
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/progress_notification.rb
+++ b/lib/magellan/gcs/proxy/progress_notification.rb
@@ -6,6 +6,23 @@ module Magellan
       module ProgressNotification
         include Log
 
+        def process_with_notification(start_no, complete_no, error_no, total, base_message, main = nil)
+          notify(start_no, total, "#{base_message} starting")
+          begin
+            main ? main.call(self) : yield(self)
+          rescue => e
+            notify(error_no, total, "#{base_message} error: [#{e.class}] #{e.message}", severity: :error)
+            raise e unless main
+          else
+            notify(complete_no, total, "#{base_message} completed")
+            yield(self) if main
+          end
+        end
+
+        def notify(progress, total, data, severity: :info)
+          notifier.notify(severity, message, data, progress: progress, total: total)
+        end
+
         def notifier
           @notifier ||= build_notifier
         end

--- a/lib/magellan/gcs/proxy/progress_notifier_adapter.rb
+++ b/lib/magellan/gcs/proxy/progress_notifier_adapter.rb
@@ -1,4 +1,4 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 module Magellan
   module Gcs
@@ -10,15 +10,14 @@ module Magellan
         end
 
         def ltsv(hash)
-          hash.map{|k,v| "#{k}:#{v}"}.join("\t")
+          hash.map { |k, v| "#{k}:#{v}" }.join("\t")
         end
 
         def notify(severity, job_message, data, attrs)
-          d = {job_message_id: job_message.message_id}.merge(attrs)
+          d = { job_message_id: job_message.message_id }.merge(attrs)
           d[:data] = data # Show data at the end of string
           logger.send(severity, ltsv(d))
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/pubsub_progress_notifier.rb
+++ b/lib/magellan/gcs/proxy/pubsub_progress_notifier.rb
@@ -1,4 +1,4 @@
-require "magellan/gcs/proxy"
+require 'magellan/gcs/proxy'
 
 require 'logger'
 require 'json'
@@ -17,9 +17,8 @@ module Magellan
         end
 
         def notify(severity, job_message, data, attrs)
-          topic.publish data, {level: severity, job_message_id: job_message.message_id}.merge(attrs)
+          topic.publish data, { level: severity, job_message_id: job_message.message_id }.merge(attrs)
         end
-
       end
     end
   end

--- a/lib/magellan/gcs/proxy/version.rb
+++ b/lib/magellan/gcs/proxy/version.rb
@@ -1,7 +1,7 @@
 module Magellan
   module Gcs
     module Proxy
-      VERSION = "0.1.1"
+      VERSION = '0.1.1'.freeze
     end
   end
 end

--- a/magellan-gcs-proxy.gemspec
+++ b/magellan-gcs-proxy.gemspec
@@ -4,30 +4,30 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'magellan/gcs/proxy/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "magellan-gcs-proxy"
+  spec.name          = 'magellan-gcs-proxy'
   spec.version       = Magellan::Gcs::Proxy::VERSION
-  spec.authors       = ["akm"]
-  spec.email         = ["akm2000@gmail.com"]
+  spec.authors       = ['akm']
+  spec.email         = ['akm2000@gmail.com']
 
-  spec.summary       = %q{Adaptor for MAGELLAN BLOCKS batch type IoT board}
-  spec.description   = %q{Adaptor for MAGELLAN BLOCKS batch type IoT board}
-  spec.homepage      = "https://github.com/groovenauts/magellan-gcs-proxy"
-  spec.license       = "MIT"
+  spec.summary       = 'Adaptor for MAGELLAN BLOCKS batch type IoT board'
+  spec.description   = 'Adaptor for MAGELLAN BLOCKS batch type IoT board'
+  spec.homepage      = 'https://github.com/groovenauts/magellan-gcs-proxy'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'dotenv'
-  spec.add_runtime_dependency "google-cloud-logging"
-  spec.add_runtime_dependency "google-cloud-pubsub"
-  spec.add_runtime_dependency "google-cloud-storage"
-  spec.add_runtime_dependency "logger_pipe"
+  spec.add_runtime_dependency 'google-cloud-logging'
+  spec.add_runtime_dependency 'google-cloud-pubsub'
+  spec.add_runtime_dependency 'google-cloud-storage'
+  spec.add_runtime_dependency 'logger_pipe'
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/magellan/gcs/proxy/cli_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_spec.rb
@@ -112,7 +112,8 @@ describe Magellan::Gcs::Proxy::Cli do
         end
 
         # Execute
-        expect(LoggerPipe).to receive(:run).with(an_instance_of(Magellan::Gcs::Proxy::CompositeLogger), cmd1_by_msg, returns: :none, logging: :both)
+        any_composite_logger = an_instance_of(Magellan::Gcs::Proxy::CompositeLogger)
+        expect(LoggerPipe).to receive(:run).with(any_composite_logger, cmd1_by_msg, returns: :none, logging: :both)
 
         # Upload
         expect(Dir).to receive(:glob).with('**/*').and_yield(upload_file_path1)
@@ -174,7 +175,12 @@ describe Magellan::Gcs::Proxy::Cli do
     subject { Magellan::Gcs::Proxy::Cli.new(template) }
     it :build_command do
       r = subject.build_command(context)
-      expected = 'cmd2 123 /tmp/workspace/downloads/path/to/bar /tmp/workspace/uploads /tmp/workspace/downloads/path/to/baz /tmp/workspace/downloads/path/to/qux1 /tmp/workspace/downloads/path/to/qux2'
+      expected = 'cmd2 123'\
+                 ' /tmp/workspace/downloads/path/to/bar'\
+                 ' /tmp/workspace/uploads'\
+                 ' /tmp/workspace/downloads/path/to/baz'\
+                 ' /tmp/workspace/downloads/path/to/qux1'\
+                 ' /tmp/workspace/downloads/path/to/qux2'
       expect(r).to eq expected
     end
   end

--- a/spec/magellan/gcs/proxy/cli_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_spec.rb
@@ -5,12 +5,12 @@ describe Magellan::Gcs::Proxy::Cli do
   let(:config_data) do
     {
       'progress_notification' => {
-        'topic' => notification_topic_name
+        'topic' => notification_topic_name,
       },
       'loggers' => [
         { 'type' => 'stdout' },
-        { 'type' => 'cloud_logging', 'log_name' => 'cloud-logging-for-rspec' }
-      ]
+        { 'type' => 'cloud_logging', 'log_name' => 'cloud-logging-for-rspec' },
+      ],
     }
   end
   before do
@@ -42,7 +42,7 @@ describe Magellan::Gcs::Proxy::Cli do
     let(:download_file_paths) do
       {
         'foo' => 'path/to/foo',
-        'bar' => 'path/to/bar'
+        'bar' => 'path/to/bar',
       }
     end
     let(:download_files) do
@@ -56,7 +56,7 @@ describe Magellan::Gcs::Proxy::Cli do
       [
         "gs://#{bucket_name}/path/to/file1",
         "gs://#{bucket_name}/path/to/file2",
-        "gs://#{bucket_name}/path/to/file3"
+        "gs://#{bucket_name}/path/to/file3",
       ]
     end
 
@@ -66,7 +66,7 @@ describe Magellan::Gcs::Proxy::Cli do
         'download_files' => download_files.to_json,
         'baz' => 60,
         'qux' => 'data1 data2 data3',
-        'upload_files' => upload_files
+        'upload_files' => upload_files,
       }
       double(:msg, message_id: message_id, attributes: attrs)
     end
@@ -144,15 +144,15 @@ describe Magellan::Gcs::Proxy::Cli do
         'baz' => 'gs://bucket2/path/to/baz',
         'qux' => [
           'gs://bucket2/path/to/qux1',
-          'gs://bucket2/path/to/qux2'
-        ]
+          'gs://bucket2/path/to/qux2',
+        ],
       }
     end
     let(:upload_files) do
       [
         'gs://bucket2/path/to/file1',
         'gs://bucket2/path/to/file2',
-        'gs://bucket2/path/to/file3'
+        'gs://bucket2/path/to/file3',
       ]
     end
 
@@ -160,7 +160,7 @@ describe Magellan::Gcs::Proxy::Cli do
       attrs = {
         'foo' => 123,
         'download_files' => download_files.to_json,
-        'upload_files' => upload_files
+        'upload_files' => upload_files,
       }
       double(:msg, attributes: attrs)
     end

--- a/spec/magellan/gcs/proxy/cli_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_spec.rb
@@ -83,7 +83,7 @@ describe Magellan::Gcs::Proxy::Cli do
 
     subject { Magellan::Gcs::Proxy::Cli.new(template) }
     it :build_command do
-      r = subject.build_command(msg, context)
+      r = subject.build_command(context)
       expect(r).to eq cmd1_by_msg
     end
 
@@ -173,7 +173,7 @@ describe Magellan::Gcs::Proxy::Cli do
 
     subject { Magellan::Gcs::Proxy::Cli.new(template) }
     it :build_command do
-      r = subject.build_command(msg, context)
+      r = subject.build_command(context)
       expected = 'cmd2 123 /tmp/workspace/downloads/path/to/bar /tmp/workspace/uploads /tmp/workspace/downloads/path/to/baz /tmp/workspace/downloads/path/to/qux1 /tmp/workspace/downloads/path/to/qux2'
       expect(r).to eq expected
     end

--- a/spec/magellan/gcs/proxy/expand_variable_spec.rb
+++ b/spec/magellan/gcs/proxy/expand_variable_spec.rb
@@ -1,29 +1,29 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Magellan::Gcs::Proxy::MessageWrapper do
   include Magellan::Gcs::Proxy::ExpandVariable
 
   context :case1 do
-    let(:downloads_dir){ '/tmp/workspace/downloads' }
-    let(:uploads_dir){ '/tmp/workspace/uploads' }
+    let(:downloads_dir) { '/tmp/workspace/downloads' }
+    let(:uploads_dir) { '/tmp/workspace/uploads' }
 
     let(:download_files) do
       {
         'foo' => 'gs://bucket1/path/to/foo',
-        'bar' => 'gs://bucket1/path/to/bar',
+        'bar' => 'gs://bucket1/path/to/bar'
       }
     end
     let(:local_download_files) do
       {
         'foo' => "#{downloads_dir}/path/to/foo",
-        'bar' => "#{downloads_dir}/path/to/bar",
+        'bar' => "#{downloads_dir}/path/to/bar"
       }
     end
     let(:upload_files) do
       [
         'gs://bucket1/path/to/file1',
         'gs://bucket1/path/to/file2',
-        'gs://bucket1/path/to/file3',
+        'gs://bucket1/path/to/file3'
       ]
     end
 
@@ -32,7 +32,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'download_files' => download_files.to_json,
         'baz' => 60,
         'qux' => 'data1 data2 data3',
-        'upload_files' => upload_files,
+        'upload_files' => upload_files
       }
       double(:msg, attributes: attrs)
     end
@@ -43,19 +43,19 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       end
     end
 
-    let(:data){ Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
 
-    it{ expect(expand_variables('%{uploads_dir}', data)).to eq uploads_dir }
-    it{ expect(expand_variables('%{attrs.baz}', data)).to eq '60' }
-    it{ expect(expand_variables('%{download_files.foo}', data)).to eq local_download_files['foo'] }
-    it{ expect(expand_variables('%{download_files.bar}', data)).to eq local_download_files['bar'] }
-    it{ expect(expand_variables('%{attrs.download_files.foo}', data)).to eq download_files['foo'] }
-    it{ expect(expand_variables('%{attrs.download_files.bar}', data)).to eq download_files['bar'] }
+    it { expect(expand_variables('%{uploads_dir}', data)).to eq uploads_dir }
+    it { expect(expand_variables('%{attrs.baz}', data)).to eq '60' }
+    it { expect(expand_variables('%{download_files.foo}', data)).to eq local_download_files['foo'] }
+    it { expect(expand_variables('%{download_files.bar}', data)).to eq local_download_files['bar'] }
+    it { expect(expand_variables('%{attrs.download_files.foo}', data)).to eq download_files['foo'] }
+    it { expect(expand_variables('%{attrs.download_files.bar}', data)).to eq download_files['bar'] }
   end
 
   context :case2 do
-    let(:downloads_dir){ '/tmp/workspace/downloads' }
-    let(:uploads_dir){ '/tmp/workspace/uploads' }
+    let(:downloads_dir) { '/tmp/workspace/downloads' }
+    let(:uploads_dir) { '/tmp/workspace/uploads' }
 
     let(:download_files) do
       {
@@ -63,8 +63,8 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => 'gs://bucket2/path/to/baz',
         'qux' => [
           'gs://bucket2/path/to/qux1',
-          'gs://bucket2/path/to/qux2',
-        ],
+          'gs://bucket2/path/to/qux2'
+        ]
       }
     end
 
@@ -74,8 +74,8 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => "#{downloads_dir}/path/to/baz",
         'qux' => [
           "#{downloads_dir}/path/to/qux1",
-          "#{downloads_dir}/path/to/qux2",
-        ],
+          "#{downloads_dir}/path/to/qux2"
+        ]
       }
     end
 
@@ -83,7 +83,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       [
         'gs://bucket2/path/to/file1',
         'gs://bucket2/path/to/file2',
-        'gs://bucket2/path/to/file3',
+        'gs://bucket2/path/to/file3'
       ]
     end
 
@@ -102,11 +102,10 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       end
     end
 
-    let(:data){ Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
 
-    it{ expect(expand_variables('%{attrs.foo}', data)).to eq '123' }
-    it{ expect(expand_variables('%{download_files.qux}', data)).to eq local_download_files['qux'].join(' ') }
-    it{ expect(expand_variables('%{attrs.download_files.qux}', data)).to eq download_files['qux'].join(' ') }
+    it { expect(expand_variables('%{attrs.foo}', data)).to eq '123' }
+    it { expect(expand_variables('%{download_files.qux}', data)).to eq local_download_files['qux'].join(' ') }
+    it { expect(expand_variables('%{attrs.download_files.qux}', data)).to eq download_files['qux'].join(' ') }
   end
-
 end

--- a/spec/magellan/gcs/proxy/expand_variable_spec.rb
+++ b/spec/magellan/gcs/proxy/expand_variable_spec.rb
@@ -43,7 +43,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       end
     end
 
-    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(context) }
 
     it { expect(expand_variables('%{uploads_dir}', data)).to eq uploads_dir }
     it { expect(expand_variables('%{attrs.baz}', data)).to eq '60' }
@@ -102,7 +102,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       end
     end
 
-    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+    let(:data) { Magellan::Gcs::Proxy::MessageWrapper.new(context) }
 
     it { expect(expand_variables('%{attrs.foo}', data)).to eq '123' }
     it { expect(expand_variables('%{download_files.qux}', data)).to eq local_download_files['qux'].join(' ') }

--- a/spec/magellan/gcs/proxy/expand_variable_spec.rb
+++ b/spec/magellan/gcs/proxy/expand_variable_spec.rb
@@ -10,20 +10,20 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
     let(:download_files) do
       {
         'foo' => 'gs://bucket1/path/to/foo',
-        'bar' => 'gs://bucket1/path/to/bar'
+        'bar' => 'gs://bucket1/path/to/bar',
       }
     end
     let(:local_download_files) do
       {
         'foo' => "#{downloads_dir}/path/to/foo",
-        'bar' => "#{downloads_dir}/path/to/bar"
+        'bar' => "#{downloads_dir}/path/to/bar",
       }
     end
     let(:upload_files) do
       [
         'gs://bucket1/path/to/file1',
         'gs://bucket1/path/to/file2',
-        'gs://bucket1/path/to/file3'
+        'gs://bucket1/path/to/file3',
       ]
     end
 
@@ -32,7 +32,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'download_files' => download_files.to_json,
         'baz' => 60,
         'qux' => 'data1 data2 data3',
-        'upload_files' => upload_files
+        'upload_files' => upload_files,
       }
       double(:msg, attributes: attrs)
     end
@@ -63,8 +63,8 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => 'gs://bucket2/path/to/baz',
         'qux' => [
           'gs://bucket2/path/to/qux1',
-          'gs://bucket2/path/to/qux2'
-        ]
+          'gs://bucket2/path/to/qux2',
+        ],
       }
     end
 
@@ -74,8 +74,8 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => "#{downloads_dir}/path/to/baz",
         'qux' => [
           "#{downloads_dir}/path/to/qux1",
-          "#{downloads_dir}/path/to/qux2"
-        ]
+          "#{downloads_dir}/path/to/qux2",
+        ],
       }
     end
 
@@ -83,7 +83,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       [
         'gs://bucket2/path/to/file1',
         'gs://bucket2/path/to/file2',
-        'gs://bucket2/path/to/file3'
+        'gs://bucket2/path/to/file3',
       ]
     end
 
@@ -91,7 +91,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       attrs = {
         'foo' => 123,
         'download_files' => download_files.to_json,
-        'upload_files' => upload_files
+        'upload_files' => upload_files,
       }
       double(:msg, attributes: attrs)
     end

--- a/spec/magellan/gcs/proxy/message_wrapper_spec.rb
+++ b/spec/magellan/gcs/proxy/message_wrapper_spec.rb
@@ -1,18 +1,18 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Magellan::Gcs::Proxy::MessageWrapper do
   context :case1 do
     let(:download_files) do
       {
         'foo' => 'gs://bucket1/path/to/foo',
-        'bar' => 'gs://bucket1/path/to/bar',
+        'bar' => 'gs://bucket1/path/to/bar'
       }
     end
     let(:upload_files) do
       [
         'gs://bucket1/path/to/file1',
         'gs://bucket1/path/to/file2',
-        'gs://bucket1/path/to/file3',
+        'gs://bucket1/path/to/file3'
       ]
     end
     let(:msg) do
@@ -20,7 +20,7 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'download_files' => download_files,
         'baz' => 60,
         'qux' => 'data1 data2 data3',
-        'upload_files' => upload_files,
+        'upload_files' => upload_files
       }
       double(:msg, attributes: attrs)
     end
@@ -28,23 +28,23 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       {
         workspace: '/tmp/workspace',
         downloads_dir: '/tmp/workspace/downloads',
-        uploads_dir: '/tmp/workspace/uploads',
+        uploads_dir: '/tmp/workspace/uploads'
       }
     end
 
     context 'wrapper' do
-      subject{ Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
-      it{ expect(subject['downloads_dir']).to eq '/tmp/workspace/downloads' }
-      it{ expect(subject['uploads_dir']).to eq '/tmp/workspace/uploads' }
-      it{ expect(subject['attrs']).to be_a(Magellan::Gcs::Proxy::MessageWrapper::Attrs) }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+      it { expect(subject['downloads_dir']).to eq '/tmp/workspace/downloads' }
+      it { expect(subject['uploads_dir']).to eq '/tmp/workspace/uploads' }
+      it { expect(subject['attrs']).to be_a(Magellan::Gcs::Proxy::MessageWrapper::Attrs) }
     end
 
     context 'attrs' do
-      subject{ Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
-      it{ expect(subject['download_files']).to eq download_files }
-      it{ expect(subject['upload_files']).to eq upload_files }
-      it{ expect(subject['baz']).to eq 60 }
-      it{ expect(subject['qux']).to eq 'data1 data2 data3' }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
+      it { expect(subject['download_files']).to eq download_files }
+      it { expect(subject['upload_files']).to eq upload_files }
+      it { expect(subject['baz']).to eq 60 }
+      it { expect(subject['qux']).to eq 'data1 data2 data3' }
     end
   end
 
@@ -55,15 +55,15 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => 'gs://bucket2/path/to/baz',
         'qux' => [
           'gs://bucket2/path/to/qux1',
-          'gs://bucket2/path/to/qux2',
-        ],
+          'gs://bucket2/path/to/qux2'
+        ]
       }
     end
     let(:upload_files) do
       [
         'gs://bucket2/path/to/file1',
         'gs://bucket2/path/to/file2',
-        'gs://bucket2/path/to/file3',
+        'gs://bucket2/path/to/file3'
       ]
     end
 
@@ -79,17 +79,15 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
       {
         workspace: '/tmp/workspace',
         downloads_dir: '/tmp/workspace/downloads',
-        uploads_dir: '/tmp/workspace/uploads',
+        uploads_dir: '/tmp/workspace/uploads'
       }
     end
 
     context 'attrs' do
-      subject{ Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
-      it{ expect(subject['foo']).to eq 123 }
-      it{ expect(subject['download_files']).to eq download_files }
-      it{ expect(subject['upload_files']).to eq upload_files }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
+      it { expect(subject['foo']).to eq 123 }
+      it { expect(subject['download_files']).to eq download_files }
+      it { expect(subject['upload_files']).to eq upload_files }
     end
-
   end
-
 end

--- a/spec/magellan/gcs/proxy/message_wrapper_spec.rb
+++ b/spec/magellan/gcs/proxy/message_wrapper_spec.rb
@@ -17,30 +17,28 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
     end
     let(:msg) do
       attrs = {
-        'download_files' => download_files,
+        'download_files' => download_files.to_json,
         'baz' => 60,
         'qux' => 'data1 data2 data3',
-        'upload_files' => upload_files
+        'upload_files' => upload_files.to_json,
       }
       double(:msg, attributes: attrs)
     end
     let(:context) do
-      {
-        workspace: '/tmp/workspace',
-        downloads_dir: '/tmp/workspace/downloads',
-        uploads_dir: '/tmp/workspace/uploads'
-      }
+      Magellan::Gcs::Proxy::Context.new(msg).tap do |c|
+        allow(c).to receive(:workspace).and_return('/tmp/workspace')
+      end
     end
 
     context 'wrapper' do
-      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context) }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(context) }
       it { expect(subject['downloads_dir']).to eq '/tmp/workspace/downloads' }
       it { expect(subject['uploads_dir']).to eq '/tmp/workspace/uploads' }
       it { expect(subject['attrs']).to be_a(Magellan::Gcs::Proxy::MessageWrapper::Attrs) }
     end
 
     context 'attrs' do
-      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(context)['attrs'] }
       it { expect(subject['download_files']).to eq download_files }
       it { expect(subject['upload_files']).to eq upload_files }
       it { expect(subject['baz']).to eq 60 }
@@ -70,21 +68,19 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
     let(:msg) do
       attrs = {
         'foo' => 123,
-        'download_files' => download_files,
-        'upload_files' => upload_files
+        'download_files' => download_files.to_json,
+        'upload_files' => upload_files.to_json,
       }
       double(:msg, attributes: attrs)
     end
     let(:context) do
-      {
-        workspace: '/tmp/workspace',
-        downloads_dir: '/tmp/workspace/downloads',
-        uploads_dir: '/tmp/workspace/uploads'
-      }
+      Magellan::Gcs::Proxy::Context.new(msg).tap do |c|
+        allow(c).to receive(:workspace).and_return('/tmp/workspace')
+      end
     end
 
     context 'attrs' do
-      subject { Magellan::Gcs::Proxy::MessageWrapper.new(msg, context)['attrs'] }
+      subject { Magellan::Gcs::Proxy::MessageWrapper.new(context)['attrs'] }
       it { expect(subject['foo']).to eq 123 }
       it { expect(subject['download_files']).to eq download_files }
       it { expect(subject['upload_files']).to eq upload_files }

--- a/spec/magellan/gcs/proxy/message_wrapper_spec.rb
+++ b/spec/magellan/gcs/proxy/message_wrapper_spec.rb
@@ -5,14 +5,14 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
     let(:download_files) do
       {
         'foo' => 'gs://bucket1/path/to/foo',
-        'bar' => 'gs://bucket1/path/to/bar'
+        'bar' => 'gs://bucket1/path/to/bar',
       }
     end
     let(:upload_files) do
       [
         'gs://bucket1/path/to/file1',
         'gs://bucket1/path/to/file2',
-        'gs://bucket1/path/to/file3'
+        'gs://bucket1/path/to/file3',
       ]
     end
     let(:msg) do
@@ -53,15 +53,15 @@ describe Magellan::Gcs::Proxy::MessageWrapper do
         'baz' => 'gs://bucket2/path/to/baz',
         'qux' => [
           'gs://bucket2/path/to/qux1',
-          'gs://bucket2/path/to/qux2'
-        ]
+          'gs://bucket2/path/to/qux2',
+        ],
       }
     end
     let(:upload_files) do
       [
         'gs://bucket2/path/to/file1',
         'gs://bucket2/path/to/file2',
-        'gs://bucket2/path/to/file3'
+        'gs://bucket2/path/to/file3',
       ]
     end
 

--- a/spec/magellan/gcs/proxy_spec.rb
+++ b/spec/magellan/gcs/proxy_spec.rb
@@ -1,7 +1,7 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe Magellan::Gcs::Proxy do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Magellan::Gcs::Proxy::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
+require "simplecov"
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "magellan/gcs/proxy"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require "simplecov"
+require 'simplecov'
 SimpleCov.start
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "magellan/gcs/proxy"
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'magellan/gcs/proxy'


### PR DESCRIPTION
- Use [simplecov](https://github.com/colszowka/simplecov) and [rubocop](http://rubocop.readthedocs.io/en/latest/).
  - `simplecov` is always used in rspec
  - `rubocops` works with `default` rake task, so `bundle exec rake` runs  both of`rubocop` task and `spec` task
- Fix offenses and change `.rubocop.yml` to pass `rubocop` task

~~This PR depends on #7 , so check the actual difference from [here](https://github.com/groovenauts/magellan-gcs-proxy/compare/45074b6...features/development_environment)~~

## Reviewers

~~Merge this PR after #7 is merged.~~

- [x] @nagachika 
- [x] @yodack 
- [x] @guemon 
