### PR TITLE
Modify deadline for log jobs

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -9,3 +9,17 @@ loggers:
 - type: cloud_logging
   log_name: <%= log_name %>
 <%- end -%>
+
+sustainer:
+  # delay:
+  #   Delay message deadline for log jobs.
+  #   It must be less than or equal to ACK_DEADLINE of subscription
+  #   specified by BLOCKS_BATCH_PUBSUB_SUBSCRIPTION
+  #   You can check ACK_DEADLINE by `gcloud beta pubsub subscriptions list`
+  #   ACK_DEADLINE is set by `--ack-deadline` option for `gcloud beta pubsub subscriptions create`.
+  delay: 600
+
+  # interval
+  #   The interval to send delay message. It must be lower than delay
+  #   Default: 90% of delay
+  interval: 540

--- a/lib/magellan/gcs/proxy.rb
+++ b/lib/magellan/gcs/proxy.rb
@@ -10,6 +10,7 @@ require 'magellan/gcs/proxy/gcp'
 require 'magellan/gcs/proxy/composite_logger'
 require 'magellan/gcs/proxy/progress_notifier_adapter'
 require 'magellan/gcs/proxy/pubsub_progress_notifier'
+require 'magellan/gcs/proxy/pubsub_sustainer'
 require 'magellan/gcs/proxy/progress_notification'
 
 require 'magellan/gcs/proxy/message_wrapper'

--- a/lib/magellan/gcs/proxy/config.rb
+++ b/lib/magellan/gcs/proxy/config.rb
@@ -17,6 +17,10 @@ module Magellan
           @data ||= load_file
         end
 
+        def reset
+          @data = nil
+        end
+
         def load_file
           erb = ERB.new(File.read(path), nil, '-')
           erb.filename = path

--- a/lib/magellan/gcs/proxy/context.rb
+++ b/lib/magellan/gcs/proxy/context.rb
@@ -23,7 +23,9 @@ module Magellan
           Dir.mktmpdir 'workspace' do |dir|
             @workspace = dir
             setup_dirs
-            yield
+            PubsubSustainer.run(message) do
+              yield
+            end
           end
         end
 

--- a/lib/magellan/gcs/proxy/log.rb
+++ b/lib/magellan/gcs/proxy/log.rb
@@ -8,7 +8,7 @@ module Magellan
         module_function
 
         def verbose(msg)
-          logger.debug(msg) if GCP.config.verbose?
+          logger.debug(msg) if Proxy.config.verbose?
         end
 
         def logger

--- a/lib/magellan/gcs/proxy/pubsub_sustainer.rb
+++ b/lib/magellan/gcs/proxy/pubsub_sustainer.rb
@@ -7,6 +7,8 @@ module Magellan
   module Gcs
     module Proxy
       class PubsubSustainer
+        include Log
+
         class << self
           def run(message)
             raise "#{name}.run requires block" unless block_given?
@@ -38,7 +40,12 @@ module Magellan
           loop do
             sleep(interval)
             break unless Thread.current[:processing_message]
-            message.delay! delay
+            begin
+              message.delay! delay
+            rescue => e
+              logger.error(e)
+              break
+            end
           end
         end
       end

--- a/lib/magellan/gcs/proxy/pubsub_sustainer.rb
+++ b/lib/magellan/gcs/proxy/pubsub_sustainer.rb
@@ -1,0 +1,47 @@
+require 'magellan/gcs/proxy'
+
+require 'logger'
+require 'json'
+
+module Magellan
+  module Gcs
+    module Proxy
+      class PubsubSustainer
+        class << self
+          def run(message)
+            raise "#{name}.run requires block" unless block_given?
+            if c = Proxy.config[:sustainer]
+              t = Thread.new(message, c['delay'], c['interval']) do |msg, delay, interval|
+                Thread.current[:processing_message] = true
+                new(msg, delay: delay, interval: interval).run
+              end
+              begin
+                yield
+              ensure
+                t[:processing_message] = false
+                t.join
+              end
+            else
+              yield
+            end
+          end
+        end
+
+        attr_reader :message, :delay, :interval
+        def initialize(message, delay: 10, interval: nil)
+          @message = message
+          @delay = delay.to_i
+          @interval = (interval || @delay * 0.9).to_f
+        end
+
+        def run
+          loop do
+            sleep(interval)
+            break unless Thread.current[:processing_message]
+            message.delay! delay
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/magellan/gcs/proxy/version.rb
+++ b/lib/magellan/gcs/proxy/version.rb
@@ -1,7 +1,7 @@
 module Magellan
   module Gcs
     module Proxy
-      VERSION = '0.1.1'.freeze
+      VERSION = '0.1.2'.freeze
     end
   end
 end

--- a/spec/magellan/gcs/proxy/cli_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_spec.rb
@@ -15,6 +15,7 @@ describe Magellan::Gcs::Proxy::Cli do
   end
   before do
     # GCP
+    Magellan::Gcs::Proxy.config.reset
     allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return(config_data)
     allow(Magellan::Gcs::Proxy::GCP).to receive(:pubsub).and_return(pubsub)
     allow(Magellan::Gcs::Proxy::GCP).to receive(:storage).and_return(storage)

--- a/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
+++ b/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Magellan::Gcs::Proxy::PubsubSustainer do
+  describe '.run' do
+    context 'with sustainer' do
+      let(:delay) { 2 }
+      let(:config_data) do
+        {
+          'loggers' => [{ 'type' => 'stdout' }],
+          'sustainer' => {
+            'delay' => delay,
+          },
+        }
+      end
+      let(:msg) { double(:msg) }
+
+      before do
+        Magellan::Gcs::Proxy.config.reset
+        allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return(config_data)
+      end
+
+      it do
+        expect(msg).to receive(:delay!).with(delay).exactly(2).times
+        Timeout.timeout 6 do
+          Magellan::Gcs::Proxy::PubsubSustainer.run(msg) do
+            sleep(5)
+          end
+        end
+      end
+    end
+
+    context 'without sustainer' do
+      let(:config_data) do
+        {
+          'loggers' => [{ 'type' => 'stdout' }],
+        }
+      end
+      let(:msg) { double(:msg) }
+
+      before do
+        Magellan::Gcs::Proxy.config.reset
+        allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return(config_data)
+      end
+
+      it do
+        expect(msg).not_to receive(:delay!)
+        Timeout.timeout 6 do
+          Magellan::Gcs::Proxy::PubsubSustainer.run(msg) do
+            sleep(5)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
+++ b/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
@@ -27,6 +27,20 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
           end
         end
       end
+
+      let(:error_message) { 'Unexpected Error' }
+      it 'logging error on delay!' do
+        Thread.current[:processing_message] = true
+        sustainer = Magellan::Gcs::Proxy::PubsubSustainer.new(msg, delay: delay)
+        logger = sustainer.send(:logger)
+        expect(logger).to receive(:error).with(instance_of(RuntimeError))
+        expect(msg).to receive(:delay!).with(delay).and_raise(error_message)
+        Timeout.timeout 4 do
+          sustainer.run do
+            sleep(3)
+          end
+        end
+      end
     end
 
     context 'without sustainer' do


### PR DESCRIPTION
Add PubsubSustainer to call [modifyAckDeadline](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline).
If `sustainer` is given in `config.yml` like the following, `magellan-gcs-proxy` uses PubsubSustainer to call `modifyAckDeadline`.

```yaml
loggers:
- type: stdout
sustainer:
  delay: 600
  interval: 540
```

I'll release `0.1.2` after this PR is merged.
