### PR TITLE
Retry to send modifyAckDeadline on Google::Cloud::UnavailableError

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    magellan-gcs-proxy (0.1.3)
+    magellan-gcs-proxy (0.1.4)
       dotenv
       google-cloud-logging
       google-cloud-pubsub

--- a/example/config.yml
+++ b/example/config.yml
@@ -17,9 +17,9 @@ sustainer:
   #   specified by BLOCKS_BATCH_PUBSUB_SUBSCRIPTION
   #   You can check ACK_DEADLINE by `gcloud beta pubsub subscriptions list`
   #   ACK_DEADLINE is set by `--ack-deadline` option for `gcloud beta pubsub subscriptions create`.
-  delay: 600
+  delay: <%= ENV['BLOCKS_BATCH_SUSTAINER_DELAY'] || 600  %>
 
   # interval
   #   The interval to send delay message. It must be lower than delay
   #   Default: 90% of delay
-  interval: 540
+  interval: <%= ENV['BLOCKS_BATCH_SUSTAINER_INTERVAL'] || 540 %>

--- a/lib/magellan/gcs/proxy/pubsub_sustainer.rb
+++ b/lib/magellan/gcs/proxy/pubsub_sustainer.rb
@@ -52,9 +52,11 @@ module Magellan
           logger.error(e)
         end
 
-        attr_reader :next_limit
+        attr_reader :next_limit, :next_deadline
         def reset_next_limit
-          @next_limit = Time.now.to_f + interval
+          now = Time.now.to_f
+          @next_limit = now + interval
+          @next_deadline = now + delay
         end
 
         def send_delay
@@ -62,7 +64,7 @@ module Magellan
           message.delay! delay
           debug("sent delay!(#{delay}) successfully")
         rescue Google::Cloud::UnavailableError => e
-          if Time.now.to_f < next_limit
+          if Time.now.to_f < next_deadline
             sleep(1) # retry interval
             debug("is retrying to send delay! cause of [#{e.class.name}] #{e.message}")
             retry

--- a/lib/magellan/gcs/proxy/pubsub_sustainer.rb
+++ b/lib/magellan/gcs/proxy/pubsub_sustainer.rb
@@ -61,6 +61,13 @@ module Magellan
           debug("is sending delay!(#{delay})")
           message.delay! delay
           debug("sent delay!(#{delay}) successfully")
+        rescue Google::Cloud::UnavailableError => e
+          if Time.now.to_f < next_limit
+            sleep(1) # retry interval
+            debug("is retrying to send delay! cause of [#{e.class.name}] #{e.message}")
+            retry
+          end
+          raise e
         end
 
         def debug(msg)

--- a/lib/magellan/gcs/proxy/pubsub_sustainer.rb
+++ b/lib/magellan/gcs/proxy/pubsub_sustainer.rb
@@ -43,13 +43,17 @@ module Magellan
               debug('is stopping.')
               break
             end
-            debug("is sending delay!(#{delay})")
-            message.delay! delay
-            debug("sent delay!(#{delay}) successfully")
+            send_delay
           end
           debug('stopped.')
         rescue => e
           logger.error(e)
+        end
+
+        def send_delay
+          debug("is sending delay!(#{delay})")
+          message.delay! delay
+          debug("sent delay!(#{delay}) successfully")
         end
 
         def debug(msg)

--- a/lib/magellan/gcs/proxy/version.rb
+++ b/lib/magellan/gcs/proxy/version.rb
@@ -1,7 +1,7 @@
 module Magellan
   module Gcs
     module Proxy
-      VERSION = '0.1.3'.freeze
+      VERSION = '0.1.4'.freeze
     end
   end
 end

--- a/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
+++ b/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
@@ -94,10 +94,9 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
       end
 
       it 'gives up retrying after the next_limit passes' do
-        expect(msg).to receive(:delay!) \
-                       .with(delay) \
-                       .and_raise(Google::Cloud::UnavailableError.new('{"description":"Secure read failed"}')) \
-                       .exactly(4).times
+        expect(msg).to receive(:delay!).with(delay) \
+          .and_raise(Google::Cloud::UnavailableError.new('{"description":"Secure read failed"}')) \
+          .exactly(4).times
         expect(subject).to receive(:next_limit).and_return(Time.now.to_f + delay).exactly(4).times
         expect { subject.send_delay }.to raise_error(Google::Cloud::UnavailableError)
       end

--- a/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
+++ b/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
@@ -6,7 +6,6 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
       let(:delay) { 2 }
       let(:config_data) do
         {
-          'loggers' => [{ 'type' => 'stdout' }],
           'sustainer' => {
             'delay' => delay,
           },
@@ -44,16 +43,11 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
     end
 
     context 'without sustainer' do
-      let(:config_data) do
-        {
-          'loggers' => [{ 'type' => 'stdout' }],
-        }
-      end
       let(:msg) { double(:msg) }
 
       before do
         Magellan::Gcs::Proxy.config.reset
-        allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return(config_data)
+        allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return('')
       end
 
       it do
@@ -71,6 +65,11 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
     let(:delay) { 3 }
     let(:interval) { 2 }
     let(:msg) { double(:msg) }
+
+    before do
+      Magellan::Gcs::Proxy.config.reset
+      allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return('')
+    end
 
     subject { Magellan::Gcs::Proxy::PubsubSustainer.new(msg, delay: delay, interval: interval) }
 

--- a/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
+++ b/spec/magellan/gcs/proxy/pubsub_sustainer_spec.rb
@@ -66,4 +66,41 @@ describe Magellan::Gcs::Proxy::PubsubSustainer do
       end
     end
   end
+
+  describe :send_delay do
+    let(:delay) { 3 }
+    let(:interval) { 2 }
+    let(:msg) { double(:msg) }
+
+    subject { Magellan::Gcs::Proxy::PubsubSustainer.new(msg, delay: delay, interval: interval) }
+
+    context 'on Google::Cloud::UnavailableError' do
+      # E, [2016-12-15T08:51:31.381860 #1] ERROR -- : 14:
+      #      {
+      #        "created":"@1481791891.380648742","description":"Secure read failed",
+      #        "file":"src/core/lib/security/transport/secure_endpoint.c","file_line":157,"grpc_status":14,
+      #        "referenced_errors":[
+      #          {"created":"@1481791891.380596379","description":"EOF","file":"src/core/lib/iomgr/tcp_posix.c","file_line":235}
+      #        ]
+      #      } (Google::Cloud::UnavailableError)
+      it 'retries until limit' do
+        cnt = 0
+        expect(msg).to receive(:delay!) do
+          cnt += 1
+          raise Google::Cloud::UnavailableError, '{"description":"Secure read failed"}' if cnt < 3
+        end.exactly(3).times
+        expect(subject).to receive(:next_limit).and_return(Time.now.to_f + delay).twice
+        subject.send_delay
+      end
+
+      it 'gives up retrying after the next_limit passes' do
+        expect(msg).to receive(:delay!) \
+                       .with(delay) \
+                       .and_raise(Google::Cloud::UnavailableError.new('{"description":"Secure read failed"}')) \
+                       .exactly(4).times
+        expect(subject).to receive(:next_limit).and_return(Time.now.to_f + delay).exactly(4).times
+        expect { subject.send_delay }.to raise_error(Google::Cloud::UnavailableError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Retry to send modifyAckDeadline if `Secure read failed` occurs.
See https://github.com/grpc/grpc/issues/7804 .

It keeps retrying until the deadline which is estimated from `sustainer/delay` of config.yml and gives up retrying after the deadline.

## Reviewers

- [x] @nagachika 
- [x] @yodack 
