### PR TITLE
Select a command from multiple commands in config.yml at runtime

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,10 @@
+AllCops:
+  DisplayCopNames: true
+
 Style/Documentation:
+  Enabled: false
+
+Style/GuardClause:
   Enabled: false
 
 LineLength:

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -12,10 +12,10 @@ GEM
     coderay (1.1.1)
     debug_inspector (0.0.2)
     digest-crc (0.4.1)
-    dotenv (2.1.2)
+    dotenv (2.2.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    google-api-client (0.9.20)
+    google-api-client (0.9.28)
       addressable (~> 2.3)
       googleauth (~> 0.5)
       httpclient (~> 2.7)
@@ -66,7 +66,7 @@ GEM
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    magellan-gcs-proxy (0.3.1)
+    magellan-gcs-proxy (0.3.2)
       dotenv
       google-cloud-logging
       google-cloud-storage

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -44,9 +44,17 @@ module Magellan
 
             case value
             when String then quote_string ? value.to_s : value
-            when Array then value.flatten.join(' ')
+            when Array, Hash then flatten(value).join(' ')
             else value.to_s
             end
+          end
+        end
+
+        def flatten(obj)
+          case obj
+          when Array then obj.map{|i| flatten(i)}
+          when Hash then flatten(obj.values)
+          else obj
           end
         end
       end

--- a/lib/magellan/gcs/proxy/expand_variable.rb
+++ b/lib/magellan/gcs/proxy/expand_variable.rb
@@ -52,7 +52,7 @@ module Magellan
 
         def flatten(obj)
           case obj
-          when Array then obj.map{|i| flatten(i)}
+          when Array then obj.map { |i| flatten(i) }
           when Hash then flatten(obj.values)
           else obj
           end

--- a/lib/magellan/gcs/proxy/version.rb
+++ b/lib/magellan/gcs/proxy/version.rb
@@ -1,7 +1,7 @@
 module Magellan
   module Gcs
     module Proxy
-      VERSION = '0.3.1'.freeze
+      VERSION = '0.3.2'.freeze
     end
   end
 end

--- a/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe Magellan::Gcs::Proxy::Cli do
+  let(:notification_topic_name) { 'progress-topic-for-rspec' }
+  let(:config_data) do
+    {
+      'progress_notification' => {
+        'topic' => notification_topic_name,
+      },
+      'loggers' => [
+        { 'type' => 'stdout' },
+        { 'type' => 'cloud_logging', 'log_name' => 'cloud-logging-for-rspec' },
+      ],
+      'commands' => {
+        'key1' => 'cmd1 %{download_files}',
+        'key2' => 'cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}',
+      }
+    }
+  end
+  before do
+    # GCP
+    Magellan::Gcs::Proxy.config.reset
+    allow(Magellan::Gcs::Proxy.config).to receive(:load_file).and_return(config_data)
+    allow(Magellan::Gcs::Proxy::GCP).to receive(:pubsub).and_return(pubsub)
+    allow(Magellan::Gcs::Proxy::GCP).to receive(:storage).and_return(storage)
+    allow(Magellan::Gcs::Proxy::GCP).to receive(:logging).and_return(logging)
+    allow(logging).to receive(:resource).with('container', {}).and_return(logging_resource)
+  end
+
+  let(:pubsub) { double(:pubsub) }
+  let(:storage) { double(:storage) }
+  let(:logging) do
+    double(:logging).tap do |l|
+      allow(l).to receive(:write_entries).with(an_instance_of(Google::Cloud::Logging::Entry),
+                                               an_instance_of(Hash))
+    end
+  end
+  let(:logging_resource) { double(:logging_resource) }
+
+  context :with_commands do
+    let(:template){ '%{attrs.foo}' }
+    let(:downloads_dir) { '/tmp/workspace/downloads' }
+    let(:uploads_dir) { '/tmp/workspace/uploads' }
+
+    let(:download_files) do
+      {
+        'bar' => 'gs://bucket2/path/to/bar',
+        'baz' => 'gs://bucket2/path/to/baz',
+        'qux' => [
+          'gs://bucket2/path/to/qux1',
+          'gs://bucket2/path/to/qux2',
+        ],
+      }
+    end
+    let(:upload_files) do
+      [
+        'gs://bucket2/path/to/file1',
+        'gs://bucket2/path/to/file2',
+        'gs://bucket2/path/to/file3',
+      ]
+    end
+
+    subject { Magellan::Gcs::Proxy::Cli.new(template) }
+
+    context "key1" do
+      let(:msg) do
+        attrs = {
+          'foo' => 'key1',
+          'download_files' => download_files.to_json,
+          'upload_files' => upload_files,
+        }
+        double(:msg, attributes: attrs)
+      end
+
+      let(:context) do
+        Magellan::Gcs::Proxy::Context.new(msg).tap do |c|
+          allow(c).to receive(:workspace).and_return('/tmp/workspace')
+        end
+      end
+
+      it do
+        r = subject.build_command(context)
+        expected = 'cmd1'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/bar'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/baz'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/qux1'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/qux2'
+        expect(r).to eq expected
+      end
+    end
+
+    context "key2" do
+      let(:msg) do
+        attrs = {
+          'foo' => 'key2',
+          'download_files' => download_files.to_json,
+          'upload_files' => upload_files,
+        }
+        double(:msg, attributes: attrs)
+      end
+
+      let(:context) do
+        Magellan::Gcs::Proxy::Context.new(msg).tap do |c|
+          allow(c).to receive(:workspace).and_return('/tmp/workspace')
+        end
+      end
+
+      it do
+        r = subject.build_command(context)
+        expected = 'cmd2'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/bar'\
+                   ' /tmp/workspace/uploads'\
+                   ' /tmp/workspace/downloads/bucket2/path/to/baz'
+        expect(r).to eq expected
+      end
+    end
+
+    context "invalid key" do
+      let(:msg) do
+        attrs = {
+          'foo' => 'invalid-key',
+          'download_files' => download_files.to_json,
+          'upload_files' => upload_files,
+        }
+        double(:msg, attributes: attrs)
+      end
+
+      let(:context) do
+        Magellan::Gcs::Proxy::Context.new(msg).tap do |c|
+          allow(c).to receive(:workspace).and_return('/tmp/workspace')
+        end
+      end
+
+      it do
+        expect{
+          subject.build_command(context)
+        }.to raise_error(Magellan::Gcs::Proxy::BuildError)
+      end
+    end
+  end
+
+end

--- a/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
@@ -131,10 +131,21 @@ describe Magellan::Gcs::Proxy::Cli do
         end
       end
 
-      it do
+      it :build_command do
         expect do
           subject.build_command(context)
         end.to raise_error(Magellan::Gcs::Proxy::BuildError)
+      end
+
+      it :build_command_with_error do
+        expect(msg).to receive(:acknowledge!)
+        expect(context).to receive(:notify).with(
+          Magellan::Gcs::Proxy::Cli::EXECUTE_ERROR,
+          Magellan::Gcs::Proxy::Cli::TOTAL,
+          an_instance_of(String)
+        )
+        cmd = subject.build_command_with_error(context)
+        expect(cmd).to be_nil
       end
     end
   end

--- a/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
+++ b/spec/magellan/gcs/proxy/cli_multiple_commands_spec.rb
@@ -14,7 +14,7 @@ describe Magellan::Gcs::Proxy::Cli do
       'commands' => {
         'key1' => 'cmd1 %{download_files}',
         'key2' => 'cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}',
-      }
+      },
     }
   end
   before do
@@ -38,7 +38,7 @@ describe Magellan::Gcs::Proxy::Cli do
   let(:logging_resource) { double(:logging_resource) }
 
   context :with_commands do
-    let(:template){ '%{attrs.foo}' }
+    let(:template) { '%{attrs.foo}' }
     let(:downloads_dir) { '/tmp/workspace/downloads' }
     let(:uploads_dir) { '/tmp/workspace/uploads' }
 
@@ -62,7 +62,7 @@ describe Magellan::Gcs::Proxy::Cli do
 
     subject { Magellan::Gcs::Proxy::Cli.new(template) }
 
-    context "key1" do
+    context 'key1' do
       let(:msg) do
         attrs = {
           'foo' => 'key1',
@@ -89,7 +89,7 @@ describe Magellan::Gcs::Proxy::Cli do
       end
     end
 
-    context "key2" do
+    context 'key2' do
       let(:msg) do
         attrs = {
           'foo' => 'key2',
@@ -115,7 +115,7 @@ describe Magellan::Gcs::Proxy::Cli do
       end
     end
 
-    context "invalid key" do
+    context 'invalid key' do
       let(:msg) do
         attrs = {
           'foo' => 'invalid-key',
@@ -132,11 +132,10 @@ describe Magellan::Gcs::Proxy::Cli do
       end
 
       it do
-        expect{
+        expect do
           subject.build_command(context)
-        }.to raise_error(Magellan::Gcs::Proxy::BuildError)
+        end.to raise_error(Magellan::Gcs::Proxy::BuildError)
       end
     end
   end
-
 end


### PR DESCRIPTION
If you have commands data in your config.yml like the following:

```
commands:
  key1: cmd1 %{download_files}
  key2: cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}
```

and you run the command by 
```
$ bundle exec magellan-gcs-proxy %{attrs.foo}
```

you can choose which command is executed by message attribute named `foo` at runtime.

| message attributes | command `magellan-gcs-proxy` calls  |
|----------|----------------------|
| `{"foo": "key1"}` |  `cmd1 %{download_files}` |
| `{"foo": "key2"}` |  `cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}` |

If the attribute value is not defined in commands keys, the message is ignored with error message.



