### PR TITLE
Environment variables support in config.json

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,6 @@
 # config.yml
 
-## command
+## Elements
 
 ### command/options
 
@@ -25,7 +25,7 @@ See [How it works/Run one of multiple commands](./how_it_works.md#run-one-of-mul
 `magellan-gcs-proxy` doesn't run command if dryrun given.
 `true`, `yes`, `on` or `1` are true. The others are false.
 
-## job
+### job
 
 ```json
 {
@@ -54,7 +54,7 @@ The new deadline will be `delay` seconds later at the time.
 See [How it works/Long time job support](https://github.com/groovenauts/magellan-gcs-proxy/blob/features/documents/doc/how_it_works.md#long-time-job-support) also.
 
 
-## progress
+### progress
 
 If you need to notify the job progresses to progress-topic, use `progress` configuration.
 It must be a map which has `topic`.
@@ -68,3 +68,9 @@ It must be a map which has `topic`.
 ```
 
 See [How it works/Progress notification](https://github.com/groovenauts/magellan-gcs-proxy/blob/features/documents/doc/how_it_works.md#progress-notification) also.
+
+
+## Environment Variables
+
+You can use environment variables in the `config.json` with `{{env "HOME"}}`.
+See [the file for test](https://github.com/groovenauts/magellan-gcs-proxy/blob/2104fb374544c78a6c240141bc131559a48fa382/test/config_with_env.json) if you need examples.

--- a/test/config_with_env.json
+++ b/test/config_with_env.json
@@ -1,0 +1,19 @@
+{
+  "command": {
+    "options": {
+      "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
+      "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
+    }
+  },
+  "job": {
+    "subscription": "projects/{{ env "GCP_PROJECT" }}/subscriptions/{{ env "PIPELINE" }}-job-subscription",
+    "pull_interval": {{ env "PULL_INTERVAL" }},
+    "sustainer": {
+      "delay": {{ env "SUSTAINER_DELAY" }},
+      "interval": {{ env "SUSTAINER_INTERVAL" }}
+    }
+  },
+  "progress": {
+    "topic": "projects/{{ env "GCP_PROJECT" }}/topics/{{ env "PIPELINE" }}-progress-topic"
+  }
+}


### PR DESCRIPTION
~~This PR depends on #19, so you can check the actual differences at https://github.com/groovenauts/magellan-gcs-proxy/compare/39af3e8...features/config_with_env~~

You can use environment variables in config.json like this:

```
{
  "command": {
    "options": {
      "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
      "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
    }
  },
  "job": {
    "subscription": "projects/{{ env "GCP_PROJECT" }}/subscriptions/{{ env "PIPELINE" }}-job-subscription",
    "pull_interval": {{ env "PULL_INTERVAL" }},
    "sustainer": {
      "delay": {{ env "SUSTAINER_DELAY" }},
      "interval": {{ env "SUSTAINER_INTERVAL" }}
    }
  },
  "progress": {
    "topic": "projects/{{ env "GCP_PROJECT" }}/topics/{{ env "PIPELINE" }}-progress-topic"
  }
}
```
