### PR TITLE
Bump up the version from 0.4.0-alpha2 to 0.4.0

### DIFF
--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.4.0-alpha2
+ENV BLOCKS_GCS_PROXY_VERSION 0.4.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/command_options/Dockerfile
+++ b/examples/command_options/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.4.0-alpha2
+ENV BLOCKS_GCS_PROXY_VERSION 0.4.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.0-alpha2"
+const VERSION = "0.4.0"


### PR DESCRIPTION
After this PR is merged, I'm going to release `blocks-gcs-proxy-0.4.0` and 2 docker containers under `examples`.
