### PR TITLE
Overwrite attributes with parsed data if specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ addons:
       - glide
 before_install:
   - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
-install:
+  - make checksetup
++install:
   ## Install dependencies
   - glide install
+before_script:
+  - make check
 script:
   - go test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 before_install:
   - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
   - make checksetup
-+install:
+install:
   ## Install dependencies
   - glide install
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,28 @@ BASENAME=blocks-gcs-proxy
 VERSION=`grep VERSION version.go | cut -f2 -d\"`
 OS=linux
 ARCH=amd64
+UNFORMATTED=$(shell gofmt -l *.go)
 
 all: build
 
 setup:
 	go get github.com/mitchellh/gox
 	go get github.com/tcnksm/ghr
+
+checksetup:
+	go get golang.org/x/tools/cmd/goimports
+
+check: checkfmt
+	go vet *.go
+	goimports -l *.go
+
+checkfmt:
+ifneq ($(UNFORMATTED),)
+	@echo $(UNFORMATTED)
+	exit 1
+else
+	@echo "gofmt -l *.go OK"
+endif
 
 build:
 	mkdir -p ${PKGDIR}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c647ff3de42f3a844861247c9d2dcc6e7ca7129d1535df9b7463f245c8492334
-updated: 2017-03-15T14:50:29.286729875+09:00
+hash: 2bcad2a5c6c4598559a5fd13ad38b0817eefa567cd1e71f837d7f9bf05c605b5
+updated: 2017-03-17T18:55:08.231159+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -14,6 +14,8 @@ imports:
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/groovenauts/blocks-variable
   version: 833d2f1e70b82c8a0a1149827906ab32aed40276
+- name: github.com/Sirupsen/logrus
+  version: 547e984ad93a90192134fc0fdb57a468edb514fe
 - name: golang.org/x/net
   version: 69d4b8aa71caaaa75c3dfc11211d1be495abec7c
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,6 +10,7 @@ import:
   - pubsub
   - pubsub/v1
   - iterator
+- package: github.com/Sirupsen/logrus
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/job.go
+++ b/job.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -179,8 +180,14 @@ func (job *Job) useDataAsAttributesIfPossible() error {
 	if !UseDataAsAttributesRegexp.MatchString(flg) {
 		return nil
 	}
+	decoded, err := base64.StdEncoding.DecodeString(job.message.raw.Message.Data)
+	if err != nil {
+		logAttrs := log.Fields{"error": err, "data": job.message.raw.Message.Data}
+		log.WithFields(logAttrs).Errorf("Failed to decode by base64")
+		return err
+	}
 	var parsed map[string]interface{}
-	err := json.Unmarshal([]byte(job.message.raw.Message.Data), &parsed)
+	err = json.Unmarshal([]byte(decoded), &parsed)
 	if err != nil {
 		logAttrs := log.Fields{"error": err, "data": job.message.raw.Message.Data}
 		log.WithFields(logAttrs).Errorf("Failed to json.Unmarshal")

--- a/job_message.go
+++ b/job_message.go
@@ -12,13 +12,32 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+type JobMessageStatus uint8
+
+const (
+	running JobMessageStatus = iota
+	done
+	acked
+)
+
+func (s JobMessageStatus) String() string {
+	switch s {
+	case running:
+		return "running"
+	case done:
+		return "done"
+	case acked:
+		return "acked"
+	default:
+		return fmt.Sprintf("JobMessageStatus[Unknown:%v]", uint8(s))
+	}
+}
+
 type (
 	JobSustainerConfig struct {
 		Delay    float64 `json:"delay,omitempty"`
 		Interval float64 `json:"interval,omitempty"`
 	}
-
-	JobMessageStatus uint8
 
 	JobMessage struct {
 		sub    string
@@ -28,12 +47,6 @@ type (
 		status JobMessageStatus
 		mux    sync.Mutex
 	}
-)
-
-const (
-	running JobMessageStatus = iota
-	done
-	acked
 )
 
 func (m *JobMessage) Validate() error {

--- a/job_setup_download_files_test.go
+++ b/job_setup_download_files_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -375,10 +376,10 @@ func TestJobSetupWithUseDataAsAttributes(t *testing.T) {
 			raw: &pubsub.ReceivedMessage{
 				AckId: "test-ack1",
 				Message: &pubsub.PubsubMessage{
-					Data: generateJSON(t, map[string]interface{}{
+					Data: base64.StdEncoding.EncodeToString([]byte(generateJSON(t, map[string]interface{}{
 						"foo":            url1,
 						"download_files": []string{url2, url3},
-					}),
+					}))),
 					Attributes: map[string]string{
 						"download_files": generateJSON(t, map[string]interface{}{
 							"foo": url1,

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"log"
 	"time"
 
 	pubsub "google.golang.org/api/pubsub/v1"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type (
@@ -71,7 +72,7 @@ func (s *JobSubscription) process(f func(*JobMessage) error) error {
 		return nil
 	}
 
-	log.Printf("Message received MessageId: %v, Message: %v\n", msg.Message.MessageId, msg.Message)
+	log.WithFields(log.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message}).Debugln("Message received")
 
 	jobMsg := &JobMessage{
 		sub:    s.config.Subscription,
@@ -91,7 +92,7 @@ func (s *JobSubscription) waitForMessage() (*pubsub.ReceivedMessage, error) {
 	}
 	res, err := s.puller.Pull(s.config.Subscription, pullRequest)
 	if err != nil {
-		log.Printf("Failed to pull %v cause of %v\n", s.config.Subscription, err)
+		log.WithFields(log.Fields{"subscription": s.config.Subscription, "error": err}).Errorln("Failed to pull")
 		return nil, err
 	}
 	if len(res.ReceivedMessages) == 0 {

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -71,7 +71,7 @@ func (s *JobSubscription) process(f func(*JobMessage) error) error {
 		return nil
 	}
 
-	log.WithFields(log.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message}).Debugln("Message received")
+	log.WithFields(log.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message}).Infoln("Message received")
 
 	jobMsg := &JobMessage{
 		sub:    s.config.Subscription,

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -60,7 +60,6 @@ func (s *JobSubscription) listen(f func(*JobMessage) error) error {
 		}
 		time.Sleep(time.Duration(s.config.PullInterval) * time.Second)
 	}
-	return nil
 }
 
 func (s *JobSubscription) process(f func(*JobMessage) error) error {

--- a/log.go
+++ b/log.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+type LogConfig struct {
+	Level string `json:"level,omitempty"`
+}
+
+func (c *LogConfig) setup() error {
+	if c.Level == "" {
+		c.Level = "info"
+	}
+	level, err := log.ParseLevel(c.Level)
+	if err != nil {
+		log.Warnf("Invalid log level: %q\n", c.Level)
+		return err
+	}
+	log.SetLevel(level)
+	return nil
+}

--- a/log_test.go
+++ b/log_test.go
@@ -8,6 +8,10 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+func init() {
+	log.SetLevel(log.PanicLevel)
+}
+
 func TestLogConfig(t *testing.T) {
 	backup := log.GetLevel()
 	defer func() {

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func TestLogConfig(t *testing.T) {
+	backup := log.GetLevel()
+	defer func() {
+		log.SetLevel(backup)
+	}()
+
+	c1 := &LogConfig{Level: "debug"}
+	c1.setup()
+	assert.Equal(t, log.DebugLevel, log.GetLevel())
+
+	c2 := &LogConfig{Level: "warn"}
+	c2.setup()
+	assert.Equal(t, log.WarnLevel, log.GetLevel())
+}

--- a/process.go
+++ b/process.go
@@ -135,7 +135,7 @@ func (p *Process) run() error {
 		err := job.run()
 		if err != nil {
 			logAttrs := log.Fields{"error": err, "msg": msg}
-			log.WithFields(logAttrs).Fatalln("Kpbg Error")
+			log.WithFields(logAttrs).Fatalln("Job Error")
 			return err
 		}
 		return nil

--- a/process.go
+++ b/process.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"text/template"
@@ -14,6 +13,8 @@ import (
 
 	pubsub "google.golang.org/api/pubsub/v1"
 	storage "google.golang.org/api/storage/v1"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 type (
@@ -75,14 +76,15 @@ func (p *Process) setup(ctx context.Context) error {
 	client, err := google.DefaultClient(ctx, pubsub.PubsubScope, storage.DevstorageReadWriteScope)
 
 	if err != nil {
-		log.Printf("Failed to create DefaultClient\n")
+		log.Fatalln("Failed to create DefaultClient")
 		return err
 	}
 
 	// Create a storageService
 	storageService, err := storage.New(client)
 	if err != nil {
-		log.Printf("Failed to create storage.Service with %v: %v\n", client, err)
+		logAttrs := log.Fields{"client": client, "error": err}
+		log.WithFields(logAttrs).Fatalln("Failed to create storage.Service")
 		return err
 	}
 	p.storage = &CloudStorage{storageService.Objects}
@@ -90,7 +92,8 @@ func (p *Process) setup(ctx context.Context) error {
 	// Creates a pubsubService
 	pubsubService, err := pubsub.New(client)
 	if err != nil {
-		log.Printf("Failed to create pubsub.Service with %v: %v\n", client, err)
+		logAttrs := log.Fields{"client": client, "error": err}
+		log.WithFields(logAttrs).Fatalln("Failed to create pubsub.Service")
 		return err
 	}
 
@@ -115,7 +118,8 @@ func (p *Process) run() error {
 		}
 		err := job.run()
 		if err != nil {
-			log.Printf("Job Error %v cause of %v\n", msg, err)
+			logAttrs := log.Fields{"error": err, "msg": msg}
+			log.WithFields(logAttrs).Fatalln("Kpbg Error")
 			return err
 		}
 		return nil

--- a/process.go
+++ b/process.go
@@ -114,6 +114,8 @@ func (p *Process) setup(ctx context.Context) error {
 }
 
 func (p *Process) run() error {
+	logAttrs := log.Fields{"VERSION": VERSION, "config": p.config}
+	log.WithFields(logAttrs).Infoln("Start listening")
 	err := p.subscription.listen(func(msg *JobMessage) error {
 		job := &Job{
 			config:       p.config.Command,

--- a/process.go
+++ b/process.go
@@ -116,14 +116,14 @@ func (p *Process) setup(ctx context.Context) error {
 func (p *Process) run() error {
 	logAttrs :=
 		log.Fields{
-		"VERSION": VERSION,
-		"config": map[string]interface{}{
-			"command":  p.config.Command,
-			"job":      p.config.Job,
-			"progress": p.config.Progress,
-			"log":      p.config.Log,
-		},
-	}
+			"VERSION": VERSION,
+			"config": map[string]interface{}{
+				"command":  p.config.Command,
+				"job":      p.config.Job,
+				"progress": p.config.Progress,
+				"log":      p.config.Log,
+			},
+		}
 	log.WithFields(logAttrs).Infoln("Start listening")
 	err := p.subscription.listen(func(msg *JobMessage) error {
 		job := &Job{

--- a/process.go
+++ b/process.go
@@ -22,6 +22,7 @@ type (
 		Command  *CommandConfig  `json:"command,omitempty"`
 		Job      *JobConfig      `json:"job,omitempty"`
 		Progress *ProgressConfig `json:"progress,omitempty"`
+		Log      *LogConfig      `json:"log,omitempty`
 	}
 )
 
@@ -30,6 +31,10 @@ func (c *ProcessConfig) setup(args []string) error {
 		c.Command = &CommandConfig{}
 	}
 	c.Command.Template = args
+	err := c.Log.setup()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/process.go
+++ b/process.go
@@ -114,7 +114,16 @@ func (p *Process) setup(ctx context.Context) error {
 }
 
 func (p *Process) run() error {
-	logAttrs := log.Fields{"VERSION": VERSION, "config": p.config}
+	logAttrs :=
+		log.Fields{
+		"VERSION": VERSION,
+		"config": map[string]interface{}{
+			"command":  p.config.Command,
+			"job":      p.config.Job,
+			"progress": p.config.Progress,
+			"log":      p.config.Log,
+		},
+	}
 	log.WithFields(logAttrs).Infoln("Start listening")
 	err := p.subscription.listen(func(msg *JobMessage) error {
 		job := &Job{

--- a/process.go
+++ b/process.go
@@ -22,7 +22,7 @@ type (
 		Command  *CommandConfig  `json:"command,omitempty"`
 		Job      *JobConfig      `json:"job,omitempty"`
 		Progress *ProgressConfig `json:"progress,omitempty"`
-		Log      *LogConfig      `json:"log,omitempty`
+		Log      *LogConfig      `json:"log,omitempty"`
 	}
 )
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.3-alpha1"
+const VERSION = "0.4.3-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.2-alpha1"
+const VERSION = "0.4.2-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.2-alpha2"
+const VERSION = "0.4.2-alpha3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.2"
+const VERSION = "0.4.3-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.1"
+const VERSION = "0.4.2-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.2-alpha3"
+const VERSION = "0.4.2"


### PR DESCRIPTION
This PR depends on #32 , so see https://github.com/groovenauts/blocks-gcs-proxy/compare/8785f06...features/use_data_as_attributes for the actual differences.

## Background

If you pass an attribute which has a long string over 1024 characters, pubsub client library raises an error like this:

```
Google::Apis::ClientError: badRequest: One of the attributes in the request has a value that is too long. The length is 1041 characters, but the maximum allowed is 1024. Refer to https://cloud.google.com/pubsub/quotas for more information.
```

So you can't use attribute to pass long string.
See also https://cloud.google.com/pubsub/quotas for more detail.

## Feature

If a client passes a long string in `data` instead of `attributes` with the attribute `use-data-as-attributes`, `blocks-gcs-proxy` parses `data` as JSON format and overwrites the attributes by parsed `data` (`use-data-as-attributes` must be `true`, `yes`, `on` or `1`)

For example, if a client publishes the following message:

```yaml
attributes:
  foo: A
  bar: B
  use-data-as-attributes: 'yes'
data: '{"foo":"Z"}'
```

`blocks-gcs-proxy` overwrites the attributes like this:

```yaml
attributes:
  foo: Z
  bar: B
  use-data-as-attributes: 'yes'
data: '{"foo":"Z"}'
```

