### PR TITLE
Fix loading config error

### DIFF
--- a/process.go
+++ b/process.go
@@ -34,7 +34,7 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Job == nil {
 		c.Job = &JobConfig{}
 	}
-	if c.Progress  == nil {
+	if c.Progress == nil {
 		c.Progress = &ProgressConfig{}
 	}
 	if c.Log == nil {

--- a/process.go
+++ b/process.go
@@ -31,6 +31,15 @@ func (c *ProcessConfig) setup(args []string) error {
 		c.Command = &CommandConfig{}
 	}
 	c.Command.Template = args
+	if c.Job == nil {
+		c.Job = &JobConfig{}
+	}
+	if c.Progress  == nil {
+		c.Progress = &ProgressConfig{}
+	}
+	if c.Log == nil {
+		c.Log = &LogConfig{}
+	}
 	err := c.Log.setup()
 	if err != nil {
 		return err

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -34,7 +34,7 @@ func TestLoadProcessConfigReal(t *testing.T) {
 		}
 		path := "./test/" + file.Name()
 		config, err := LoadProcessConfig(path)
-		if assert.NoError(t, err, "path: " + path) {
+		if assert.NoError(t, err, "path: "+path) {
 			assert.NotNil(t, config)
 			err = config.setup([]string{"%{attrs.command}"})
 			assert.NoError(t, err)

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -6,15 +6,40 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var ConfigFilePattern = regexp.MustCompile(`\.json\z`)
+
 func TestLoadProcessConfigReal(t *testing.T) {
-	_, err := LoadProcessConfig("./test/config1.json")
+	oldProject := os.Getenv("GCP_PROJECT")
+	defer func() {
+		err := os.Setenv("GCP_PROJECT", oldProject)
+		assert.NoError(t, err)
+	}()
+	os.Setenv("GCP_PROJECT", "dummy-proj-999")
+	os.Setenv("PIPELINE", "pipeline01")
+	os.Setenv("PULL_INTERVAL", "60")
+	os.Setenv("SUSTAINER_DELAY", "600")
+	os.Setenv("SUSTAINER_INTERVAL", "540")
+	files, err := ioutil.ReadDir("./test")
 	assert.NoError(t, err)
+	for _, file := range files {
+		if !ConfigFilePattern.MatchString(file.Name()) {
+			continue
+		}
+		path := "./test/" + file.Name()
+		config, err := LoadProcessConfig(path)
+		if assert.NoError(t, err, "path: " + path) {
+			assert.NotNil(t, config)
+			err = config.setup([]string{"%{attrs.command}"})
+			assert.NoError(t, err)
+		}
+	}
 }
 
 func tempEnv(t *testing.T, env map[string]string, f func()) {

--- a/test/full.json
+++ b/test/full.json
@@ -1,0 +1,23 @@
+{
+  "command": {
+    "options": {
+      "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
+      "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
+    },
+    "dryrun": true
+  },
+  "job": {
+    "subscription": "projects/dummy-gcp-proj/subscriptions/test-job-subscription",
+    "pull_interval": 60,
+    "sustainer": {
+      "delay": 600,
+      "interval": 540
+    }
+  },
+  "progress": {
+    "topic": "projects/dummy-gcp-proj/topics/test-progress-topic"
+  },
+  "log": {
+    "level": "debug"
+  }
+}


### PR DESCRIPTION
- Fix error on loading config.file without `log`.
- Improve `process_config_test.go` 
    - Call `*ProcessConfig.setup()` after `LoadProcessConfig`
    - Add some test files to load
