### PR TITLE
Parallel upload

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -27,18 +27,14 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	ctx := context.Background()
-
-	configPath := c.String("config")
-	if configPath == "" {
-		configPath = "./config.json"
-	}
-	config, err := LoadProcessConfig(configPath)
+	config, err := LoadProcessConfig(configPath(c))
 	if err != nil {
 		fmt.Printf("Error to load %v cause of %v\n", configPath, err)
 		os.Exit(1)
 	}
 	config.setup(os.Args[1:])
+
+	ctx := context.Background()
 
 	p := &Process{config: config}
 	err = p.setup(ctx)
@@ -53,4 +49,12 @@ func run(c *cli.Context) error {
 		os.Exit(1)
 	}
 	return nil
+}
+
+func configPath(c *cli.Context) string {
+	r := c.String("config")
+	if r == "" {
+		r = "./config.json"
+	}
+	return r
 }

--- a/cli.go
+++ b/cli.go
@@ -40,6 +40,7 @@ func main() {
 			Usage: "Upload the files under uploads directory",
 			Action: func(c *cli.Context) error {
 				config := &ProcessConfig{}
+				config.Log = &LogConfig{Level: "debug"}
 				config.setup([]string{})
 				config.Command.Uploaders = c.Int("uploaders")
 				job := &Job{

--- a/cli.go
+++ b/cli.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/urfave/cli"
-	"golang.org/x/net/context"
 )
 
 func main() {
@@ -72,10 +71,8 @@ func main() {
 func run(c *cli.Context) error {
 	config := LoadAndSetupProcessConfig(c)
 
-	ctx := context.Background()
-
 	p := &Process{config: config}
-	err := p.setup(ctx)
+	err := p.setup()
 	if err != nil {
 		fmt.Printf("Error to setup Process cause of %v\n", err)
 		os.Exit(1)

--- a/cli.go
+++ b/cli.go
@@ -45,9 +45,9 @@ func main() {
 				p := setupProcess(config)
 				p.setup()
 				job := &Job{
-					config: config.Command,
+					config:      config.Command,
 					uploads_dir: c.String("uploads_dir"),
-					storage: p.storage,
+					storage:     p.storage,
 				}
 				err := job.uploadFiles()
 				return err

--- a/cli.go
+++ b/cli.go
@@ -22,19 +22,19 @@ func main() {
 		configFlag,
 	}
 
-  app.Commands = []cli.Command{
-    {
-      Name:    "check",
-      Usage:   "Check config file is valid",
-      Action:  func(c *cli.Context) error {
+	app.Commands = []cli.Command{
+		{
+			Name:  "check",
+			Usage: "Check config file is valid",
+			Action: func(c *cli.Context) error {
 				LoadAndSetupProcessConfig(c)
 				fmt.Println("OK")
-        return nil
-      },
-		  Flags: []cli.Flag{
+				return nil
+			},
+			Flags: []cli.Flag{
 				configFlag,
 			},
-    },
+		},
 	}
 
 	app.Action = run

--- a/cli.go
+++ b/cli.go
@@ -60,7 +60,7 @@ func main() {
 				cli.IntFlag{
 					Name:  "uploaders, n",
 					Usage: "Number of uploaders",
-					Value: 1,
+					Value: 6,
 				},
 			},
 		},

--- a/cli.go
+++ b/cli.go
@@ -4,13 +4,35 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/urfave/cli"
 	"golang.org/x/net/context"
 )
 
 func main() {
+	app := cli.NewApp()
+	app.Name = "blocks-gcs-proxy"
+	app.Usage = "github.com/groovenauts/blocks-gcs-proxy"
+	app.Version = VERSION
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "config, c",
+			Usage: "Load configuration from `FILE`",
+		},
+	}
+
+	app.Action = run
+
+	app.Run(os.Args)
+}
+
+func run(c *cli.Context) error {
 	ctx := context.Background()
 
-	configPath := "./config.json"
+	configPath := c.String("config")
+	if configPath == "" {
+		configPath = "./config.json"
+	}
 	config, err := LoadProcessConfig(configPath)
 	if err != nil {
 		fmt.Printf("Error to load %v cause of %v\n", configPath, err)
@@ -30,4 +52,5 @@ func main() {
 		fmt.Printf("Error to run cause of %v\n", err)
 		os.Exit(1)
 	}
+	return nil
 }

--- a/cli.go
+++ b/cli.go
@@ -27,17 +27,12 @@ func main() {
 }
 
 func run(c *cli.Context) error {
-	config, err := LoadProcessConfig(configPath(c))
-	if err != nil {
-		fmt.Printf("Error to load %v cause of %v\n", configPath, err)
-		os.Exit(1)
-	}
-	config.setup(os.Args[1:])
+	config := LoadAndSetupProcessConfig(c)
 
 	ctx := context.Background()
 
 	p := &Process{config: config}
-	err = p.setup(ctx)
+	err := p.setup(ctx)
 	if err != nil {
 		fmt.Printf("Error to setup Process cause of %v\n", err)
 		os.Exit(1)
@@ -49,6 +44,21 @@ func run(c *cli.Context) error {
 		os.Exit(1)
 	}
 	return nil
+}
+
+func LoadAndSetupProcessConfig(c *cli.Context) *ProcessConfig {
+	path := configPath(c)
+	config, err := LoadProcessConfig(path)
+	if err != nil {
+		fmt.Printf("Error to load %v cause of %v\n", path, err)
+		os.Exit(1)
+	}
+	err = config.setup(os.Args[1:])
+	if err != nil {
+		fmt.Printf("Error to setup %v cause of %v\n", path, err)
+		os.Exit(1)
+	}
+	return config
 }
 
 func configPath(c *cli.Context) string {

--- a/cli.go
+++ b/cli.go
@@ -42,9 +42,12 @@ func main() {
 				config.Log = &LogConfig{Level: "debug"}
 				config.setup([]string{})
 				config.Command.Uploaders = c.Int("uploaders")
+				p := setupProcess(config)
+				p.setup()
 				job := &Job{
 					config: config.Command,
 					uploads_dir: c.String("uploads_dir"),
+					storage: p.storage,
 				}
 				err := job.uploadFiles()
 				return err
@@ -70,20 +73,24 @@ func main() {
 
 func run(c *cli.Context) error {
 	config := LoadAndSetupProcessConfig(c)
+	p := setupProcess(config)
 
+	err := p.run()
+	if err != nil {
+		fmt.Printf("Error to run cause of %v\n", err)
+		os.Exit(1)
+	}
+	return nil
+}
+
+func setupProcess(config *ProcessConfig) *Process {
 	p := &Process{config: config}
 	err := p.setup()
 	if err != nil {
 		fmt.Printf("Error to setup Process cause of %v\n", err)
 		os.Exit(1)
 	}
-
-	err = p.run()
-	if err != nil {
-		fmt.Printf("Error to run cause of %v\n", err)
-		os.Exit(1)
-	}
-	return nil
+	return p
 }
 
 func LoadAndSetupProcessConfig(c *cli.Context) *ProcessConfig {

--- a/cli.go
+++ b/cli.go
@@ -35,6 +35,32 @@ func main() {
 				configFlag,
 			},
 		},
+		{
+			Name:  "upload",
+			Usage: "Upload the files under uploads directory",
+			Action: func(c *cli.Context) error {
+				config := &ProcessConfig{}
+				config.setup([]string{})
+				config.Command.Uploaders = c.Int("uploaders")
+				job := &Job{
+					config: config.Command,
+					uploads_dir: c.String("uploads_dir"),
+				}
+				err := job.uploadFiles()
+				return err
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "uploads_dir, d",
+					Usage: "Path to the directory which has bucket_name/path/to/file",
+				},
+				cli.IntFlag{
+					Name:  "uploaders, n",
+					Usage: "Number of uploaders",
+					Value: 1,
+				},
+			},
+		},
 	}
 
 	app.Action = run

--- a/cli.go
+++ b/cli.go
@@ -14,11 +14,27 @@ func main() {
 	app.Usage = "github.com/groovenauts/blocks-gcs-proxy"
 	app.Version = VERSION
 
+	configFlag := cli.StringFlag{
+		Name:  "config, c",
+		Usage: "Load configuration from `FILE`",
+	}
 	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:  "config, c",
-			Usage: "Load configuration from `FILE`",
-		},
+		configFlag,
+	}
+
+  app.Commands = []cli.Command{
+    {
+      Name:    "check",
+      Usage:   "Check config file is valid",
+      Action:  func(c *cli.Context) error {
+				LoadAndSetupProcessConfig(c)
+				fmt.Println("OK")
+        return nil
+      },
+		  Flags: []cli.Flag{
+				configFlag,
+			},
+    },
 	}
 
 	app.Action = run

--- a/file_storage.go
+++ b/file_storage.go
@@ -114,14 +114,14 @@ func (w *TargetWorker) run() {
 type TargetWorkers []*TargetWorker
 
 func (ws TargetWorkers) process(targets []*Target) error {
-	c := make(chan *Target)
+	c := make(chan *Target, len(targets))
+	for _, t := range targets {
+		c <- t
+	}
+
 	for _, w := range ws {
 		w.targets = c
 		go w.run()
-	}
-
-	for _, t := range targets {
-		c <- t
 	}
 
 	for {

--- a/file_storage.go
+++ b/file_storage.go
@@ -88,17 +88,22 @@ type TargetWorker struct {
 
 func (w *TargetWorker) run() {
 	for {
+		log.Debugln("Getting a target")
 		t, ok := <-w.targets
+		flds := log.Fields{"target": t, "ok": ok}
+		log.WithFields(flds).Debugln("Got a target")
 		if !ok {
+			log.WithFields(flds).Debugln("Not ok")
 			w.done = true
 			w.error = nil
 			break
 		}
 
 		err := w.impl(t.Bucket, t.Object, t.LocalPath)
+		flds["error"] = err
+		log.WithFields(flds).Debugln("Uploaded")
 		if err != nil {
-			logAttrs := log.Fields{"target": t}
-			log.WithFields(logAttrs).Errorf("Failed to %v file", w.name)
+			log.WithFields(flds).Errorf("Failed to %v file", w.name)
 			w.done = true
 			w.error = err
 			break

--- a/file_storage.go
+++ b/file_storage.go
@@ -92,7 +92,7 @@ func (w *TargetWorker) run() {
 		log.Debugln("Getting a target")
 		var t *Target
 		select {
-		case t = <- w.targets:
+		case t = <-w.targets:
 		default: // Do nothing to break
 		}
 		if t == nil {

--- a/file_storage.go
+++ b/file_storage.go
@@ -108,9 +108,15 @@ func (w *TargetWorker) run() {
 
 type TargetWorkers []*TargetWorker
 
-func (ws TargetWorkers) runAndWait() error {
+func (ws TargetWorkers) process(targets []*Target) error {
+	c := make(chan *Target)
 	for _, w := range ws {
+		w.targets = c
 		go w.run()
+	}
+
+	for _, t := range targets {
+		c <- t
 	}
 
 	for {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2bcad2a5c6c4598559a5fd13ad38b0817eefa567cd1e71f837d7f9bf05c605b5
-updated: 2017-03-17T18:55:08.231159+09:00
+hash: bf87879ced09f19ce67bb399ef94042e2c1bbd0ad6986bff00564dd3aecf16eb
+updated: 2017-04-05T17:04:20.624985192+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -16,6 +16,8 @@ imports:
   version: 833d2f1e70b82c8a0a1149827906ab32aed40276
 - name: github.com/Sirupsen/logrus
   version: 547e984ad93a90192134fc0fdb57a468edb514fe
+- name: github.com/urfave/cli
+  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
 - name: golang.org/x/net
   version: 69d4b8aa71caaaa75c3dfc11211d1be495abec7c
   subpackages:
@@ -34,6 +36,10 @@ imports:
   - internal
   - jws
   - jwt
+- name: golang.org/x/sys
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  subpackages:
+  - unix
 - name: google.golang.org/api
   version: b9d03e6e091e36f9a089515bc84cf14c2d199c4c
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/groovenauts/blocks-concurrent-subscriber
 import:
 - package: github.com/groovenauts/blocks-variable
+- package: github.com/urfave/cli
 - package: golang.org/x/net
   subpackages:
   - context

--- a/job.go
+++ b/job.go
@@ -409,15 +409,11 @@ func (job *Job) uploadFiles() error {
 	log.WithFields(log.Fields{"files": localPaths}).Debugln("Uploading files found")
 	targets := []*Target{}
 	for _, localPath := range localPaths {
-		flds := log.Fields{"localPath": localPath}
-		log.WithFields(flds).Debugln("Preparing targets #1")
 		relPath, err := filepath.Rel(job.uploads_dir, localPath)
 		if err != nil {
 			log.WithFields(log.Fields{"error": err, "localPath": localPath, "uploads_dir": job.uploads_dir}).Errorln("Failed to get relative path")
 			return err
 		}
-		flds["relPath"] = relPath
-		log.WithFields(flds).Debugln("Preparing targets #2")
 		sep := string([]rune{os.PathSeparator})
 		parts := strings.Split(relPath, sep)
 		t := Target{
@@ -425,10 +421,8 @@ func (job *Job) uploadFiles() error {
 			Object:    strings.Join(parts[1:], sep),
 			LocalPath: localPath,
 		}
-		flds["target"] = t
-		log.WithFields(flds).Debugln("Preparing targets #3")
 		targets = append(targets, &t)
-		log.WithFields(flds).Debugln("Preparing targets #4")
+		log.WithFields(log.Fields{"target": t}).Debugln("Preparing targets")
 	}
 
 	if job.config.Uploaders < 1 {

--- a/job.go
+++ b/job.go
@@ -24,6 +24,7 @@ type (
 		Template []string            `json:"-"`
 		Options  map[string][]string `json:"options,omitempty"`
 		Dryrun   bool                `json:"dryrun,omitempty"`
+		Uploaders int                `json:"uploaders,omitempty"`
 	}
 
 	Job struct {
@@ -422,8 +423,11 @@ func (job *Job) uploadFiles() error {
 		targets <- t
 	}
 
+	if job.config.Uploaders < 1 {
+		job.config.Uploaders = 1
+	}
 	uploaders := TargetWorkers{}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < job.config.Uploaders; i++ {
 		uploader := &TargetWorker{
 			name:    "upload",
 			targets: targets,

--- a/job.go
+++ b/job.go
@@ -21,10 +21,10 @@ import (
 
 type (
 	CommandConfig struct {
-		Template []string            `json:"-"`
-		Options  map[string][]string `json:"options,omitempty"`
-		Dryrun   bool                `json:"dryrun,omitempty"`
-		Uploaders int                `json:"uploaders,omitempty"`
+		Template  []string            `json:"-"`
+		Options   map[string][]string `json:"options,omitempty"`
+		Dryrun    bool                `json:"dryrun,omitempty"`
+		Uploaders int                 `json:"uploaders,omitempty"`
 	}
 
 	Job struct {
@@ -431,8 +431,8 @@ func (job *Job) uploadFiles() error {
 	uploaders := TargetWorkers{}
 	for i := 0; i < job.config.Uploaders; i++ {
 		uploader := &TargetWorker{
-			name:    "upload",
-			impl:    job.storage.Upload,
+			name: "upload",
+			impl: job.storage.Upload,
 		}
 		uploaders = append(uploaders, uploader)
 	}

--- a/process.go
+++ b/process.go
@@ -85,7 +85,9 @@ type (
 	}
 )
 
-func (p *Process) setup(ctx context.Context) error {
+func (p *Process) setup() error {
+	ctx := context.Background()
+
 	// https://github.com/google/google-api-go-client#application-default-credentials-example
 	client, err := google.DefaultClient(ctx, pubsub.PubsubScope, storage.DevstorageReadWriteScope)
 

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -117,6 +117,7 @@ func TestLoadProcessConfigWithDefaultValues(t *testing.T) {
 			assert.Equal(t, float64(600), config.Job.Sustainer.Delay)
 			assert.Equal(t, float64(540), config.Job.Sustainer.Interval)
 			assert.Equal(t, fmt.Sprintf("projects/%v/topics/%v-progress-topic", proj, pipeline), config.Progress.Topic)
+			assert.Equal(t, int(8), config.Command.Uploaders)
 		}
 	})
 }

--- a/test/config_with_env_and_default3.json
+++ b/test/config_with_env_and_default3.json
@@ -3,7 +3,8 @@
     "options": {
       "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
-    }
+    },
+    "uploaders": {{ or .UPLOADERS 8}}
   },
   "job": {
     "subscription": "projects/{{ .GCP_PROJECT }}/subscriptions/{{ or .PIPELINE "pipeline01" }}-job-subscription",

--- a/test/full.json
+++ b/test/full.json
@@ -4,7 +4,8 @@
       "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
     },
-    "dryrun": true
+    "dryrun": true,
+    "uploaders": 8
   },
   "job": {
     "subscription": "projects/dummy-gcp-proj/subscriptions/test-job-subscription",

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.0-alpha2"
+const VERSION = "0.5.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.4.3"
+const VERSION = "0.5.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.0-alpha1"
+const VERSION = "0.5.0-alpha2"


### PR DESCRIPTION
To improve uploading, call upload method from some go routines.

This PR depends on #36 , so see https://github.com/groovenauts/blocks-gcs-proxy/compare/221bf1e...features/parallel_upload for actual differences.

You can try to upload manually by using subcommand `upload` like this:

```
$ ./blocks-gcs-proxy upload -d tmp/uploads -n 5
```

In production, you can set the number of uploader in config.json like [this example](https://github.com/groovenauts/blocks-gcs-proxy/blob/8d4bc71935f3cf0f0ce12e1f785daa8a4a32a9ba/test/config_with_env_and_default3.json#L7)
