### PR TITLE
Parallel download

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -35,6 +35,45 @@ func main() {
 			},
 		},
 		{
+			Name:  "download",
+			Usage: "Download the files under downloads directory",
+			Action: func(c *cli.Context) error {
+				config := &ProcessConfig{}
+				config.Log = &LogConfig{Level: "debug"}
+				config.setup([]string{})
+				config.Command.Downloaders = c.Int("downloaders")
+				p := setupProcess(config)
+				p.setup()
+				files := []interface{}{}
+				for _, arg := range c.Args() {
+					files = append(files, arg)
+				}
+				job := &Job{
+					config:      config.Command,
+					downloads_dir: c.String("downloads_dir"),
+					remoteDownloadFiles: files,
+					storage:     p.storage,
+				}
+				err := job.setupDownloadFiles()
+				if err != nil {
+					return err
+				}
+				err = job.downloadFiles()
+				return err
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "downloads_dir, d",
+					Usage: "Path to the directory which has bucket_name/path/to/file",
+				},
+				cli.IntFlag{
+					Name:  "downloaders, n",
+					Usage: "Number of downloaders",
+					Value: 6,
+				},
+			},
+		},
+		{
 			Name:  "upload",
 			Usage: "Upload the files under uploads directory",
 			Action: func(c *cli.Context) error {

--- a/cli.go
+++ b/cli.go
@@ -49,10 +49,10 @@ func main() {
 					files = append(files, arg)
 				}
 				job := &Job{
-					config:      config.Command,
-					downloads_dir: c.String("downloads_dir"),
+					config:              config.Command,
+					downloads_dir:       c.String("downloads_dir"),
 					remoteDownloadFiles: files,
-					storage:     p.storage,
+					storage:             p.storage,
 				}
 				err := job.setupDownloadFiles()
 				if err != nil {

--- a/job.go
+++ b/job.go
@@ -21,11 +21,11 @@ import (
 
 type (
 	CommandConfig struct {
-		Template  []string            `json:"-"`
-		Options   map[string][]string `json:"options,omitempty"`
-		Dryrun    bool                `json:"dryrun,omitempty"`
-		Uploaders int                 `json:"uploaders,omitempty"`
-		Downloaders int               `json:"downloaders,omitempty"`
+		Template    []string            `json:"-"`
+		Options     map[string][]string `json:"options,omitempty"`
+		Dryrun      bool                `json:"dryrun,omitempty"`
+		Uploaders   int                 `json:"uploaders,omitempty"`
+		Downloaders int                 `json:"downloaders,omitempty"`
 	}
 
 	Job struct {

--- a/job.go
+++ b/job.go
@@ -126,6 +126,7 @@ func (job *Job) prepare() error {
 		return err
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	if err != nil {
 		return err
@@ -216,7 +217,6 @@ func (job *Job) useDataAsAttributesIfPossible() error {
 
 func (job *Job) setupDownloadFiles() error {
 	job.downloadFileMap = map[string]string{}
-	job.remoteDownloadFiles = job.message.DownloadFiles()
 	objects := job.flatten(job.remoteDownloadFiles)
 	remoteUrls := []string{}
 	for _, obj := range objects {

--- a/job.go
+++ b/job.go
@@ -404,6 +404,7 @@ func (job *Job) downloadFiles() error {
 	}
 	log.WithFields(log.Fields{"downloaders": len(downloaders)}).Debugln("Downloaders are running")
 
+	log.WithFields(log.Fields{"targets": targets}).Debugln("downloaders processing")
 	err := downloaders.process(targets)
 	return err
 }

--- a/job.go
+++ b/job.go
@@ -397,7 +397,7 @@ func (job *Job) downloadFiles() error {
 	downloaders := TargetWorkers{}
 	for i := 0; i < job.config.Downloaders; i++ {
 		downloader := &TargetWorker{
-			name: "upload",
+			name: "downoad",
 			impl: job.storage.Download,
 		}
 		downloaders = append(downloaders, downloader)

--- a/job.go
+++ b/job.go
@@ -25,6 +25,7 @@ type (
 		Options   map[string][]string `json:"options,omitempty"`
 		Dryrun    bool                `json:"dryrun,omitempty"`
 		Uploaders int                 `json:"uploaders,omitempty"`
+		Downloaders int               `json:"downloaders,omitempty"`
 	}
 
 	Job struct {
@@ -367,6 +368,7 @@ func (job *Job) convertError(src error) error {
 }
 
 func (job *Job) downloadFiles() error {
+	targets := []*Target{}
 	for remoteURL, destPath := range job.downloadFileMap {
 		url, err := url.Parse(remoteURL)
 		if err != nil {
@@ -380,12 +382,30 @@ func (job *Job) downloadFiles() error {
 			return err
 		}
 
-		err = job.storage.Download(url.Host, url.Path[1:], destPath)
-		if err != nil {
-			return err
+		t := Target{
+			Bucket:    url.Host,
+			Object:    url.Path[1:],
+			LocalPath: destPath,
 		}
+		targets = append(targets, &t)
+		log.WithFields(log.Fields{"target": t}).Debugln("Preparing targets")
 	}
-	return nil
+
+	if job.config.Downloaders < 1 {
+		job.config.Downloaders = 1
+	}
+	downloaders := TargetWorkers{}
+	for i := 0; i < job.config.Downloaders; i++ {
+		downloader := &TargetWorker{
+			name: "upload",
+			impl: job.storage.Download,
+		}
+		downloaders = append(downloaders, downloader)
+	}
+	log.WithFields(log.Fields{"downloaders": len(downloaders)}).Debugln("Downloaders are running")
+
+	err := downloaders.process(targets)
+	return err
 }
 
 func (job *Job) execute() error {

--- a/job_setup_download_files_test.go
+++ b/job_setup_download_files_test.go
@@ -46,6 +46,7 @@ func TestJobSetupCase1(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err := job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -102,6 +103,7 @@ func TestJobSetupCase2(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err := job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -180,6 +182,7 @@ func TestJobSetupCase3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, attrs["foo"], val)
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -259,6 +262,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, attrs["foo"], val)
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -301,6 +305,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 		downloads_dir: downloads_dir,
 		uploads_dir:   uploads_dir,
 	}
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -344,6 +349,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -401,6 +407,7 @@ func TestJobSetupWithUseDataAsAttributes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, url1, job.message.raw.Message.Attributes["foo"])
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 

--- a/test/full.json
+++ b/test/full.json
@@ -5,6 +5,7 @@
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
     },
     "dryrun": true,
+    "downloaders": 5,
     "uploaders": 8
   },
   "job": {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.0"
+const VERSION = "0.5.1-alpha1"


### PR DESCRIPTION
To improve downloading, call download method from some go routines.

You can try to download manually by using subcommand `download` like this:

```
$ ./blocks-gcs-proxy download -d tmp/downloads -n 5 gs://bucket1/path/to/file1  gs://bucket1/path/to/file2  gs://bucket1/path/to/file3
```

In production, you can set the number of downloader in config.json like [this example](https://github.com/groovenauts/blocks-gcs-proxy/blob/features/parallel_download/test/full.json#L8)