### PR TITLE
Automatic sustainer configurations

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -35,6 +35,45 @@ func main() {
 			},
 		},
 		{
+			Name:  "download",
+			Usage: "Download the files under downloads directory",
+			Action: func(c *cli.Context) error {
+				config := &ProcessConfig{}
+				config.Log = &LogConfig{Level: "debug"}
+				config.setup([]string{})
+				config.Command.Downloaders = c.Int("downloaders")
+				p := setupProcess(config)
+				p.setup()
+				files := []interface{}{}
+				for _, arg := range c.Args() {
+					files = append(files, arg)
+				}
+				job := &Job{
+					config:      config.Command,
+					downloads_dir: c.String("downloads_dir"),
+					remoteDownloadFiles: files,
+					storage:     p.storage,
+				}
+				err := job.setupDownloadFiles()
+				if err != nil {
+					return err
+				}
+				err = job.downloadFiles()
+				return err
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "downloads_dir, d",
+					Usage: "Path to the directory which has bucket_name/path/to/file",
+				},
+				cli.IntFlag{
+					Name:  "downloaders, n",
+					Usage: "Number of downloaders",
+					Value: 6,
+				},
+			},
+		},
+		{
 			Name:  "upload",
 			Usage: "Upload the files under uploads directory",
 			Action: func(c *cli.Context) error {

--- a/cli.go
+++ b/cli.go
@@ -49,10 +49,10 @@ func main() {
 					files = append(files, arg)
 				}
 				job := &Job{
-					config:      config.Command,
-					downloads_dir: c.String("downloads_dir"),
+					config:              config.Command,
+					downloads_dir:       c.String("downloads_dir"),
 					remoteDownloadFiles: files,
-					storage:     p.storage,
+					storage:             p.storage,
 				}
 				err := job.setupDownloadFiles()
 				if err != nil {

--- a/job.go
+++ b/job.go
@@ -21,11 +21,11 @@ import (
 
 type (
 	CommandConfig struct {
-		Template  []string            `json:"-"`
-		Options   map[string][]string `json:"options,omitempty"`
-		Dryrun    bool                `json:"dryrun,omitempty"`
-		Uploaders int                 `json:"uploaders,omitempty"`
-		Downloaders int               `json:"downloaders,omitempty"`
+		Template    []string            `json:"-"`
+		Options     map[string][]string `json:"options,omitempty"`
+		Dryrun      bool                `json:"dryrun,omitempty"`
+		Uploaders   int                 `json:"uploaders,omitempty"`
+		Downloaders int                 `json:"downloaders,omitempty"`
 	}
 
 	Job struct {

--- a/job.go
+++ b/job.go
@@ -126,6 +126,7 @@ func (job *Job) prepare() error {
 		return err
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	if err != nil {
 		return err
@@ -216,7 +217,6 @@ func (job *Job) useDataAsAttributesIfPossible() error {
 
 func (job *Job) setupDownloadFiles() error {
 	job.downloadFileMap = map[string]string{}
-	job.remoteDownloadFiles = job.message.DownloadFiles()
 	objects := job.flatten(job.remoteDownloadFiles)
 	remoteUrls := []string{}
 	for _, obj := range objects {

--- a/job.go
+++ b/job.go
@@ -404,6 +404,7 @@ func (job *Job) downloadFiles() error {
 	}
 	log.WithFields(log.Fields{"downloaders": len(downloaders)}).Debugln("Downloaders are running")
 
+	log.WithFields(log.Fields{"targets": targets}).Debugln("downloaders processing")
 	err := downloaders.process(targets)
 	return err
 }

--- a/job.go
+++ b/job.go
@@ -397,7 +397,7 @@ func (job *Job) downloadFiles() error {
 	downloaders := TargetWorkers{}
 	for i := 0; i < job.config.Downloaders; i++ {
 		downloader := &TargetWorker{
-			name: "upload",
+			name: "downoad",
 			impl: job.storage.Download,
 		}
 		downloaders = append(downloaders, downloader)

--- a/job.go
+++ b/job.go
@@ -25,6 +25,7 @@ type (
 		Options   map[string][]string `json:"options,omitempty"`
 		Dryrun    bool                `json:"dryrun,omitempty"`
 		Uploaders int                 `json:"uploaders,omitempty"`
+		Downloaders int               `json:"downloaders,omitempty"`
 	}
 
 	Job struct {
@@ -367,6 +368,7 @@ func (job *Job) convertError(src error) error {
 }
 
 func (job *Job) downloadFiles() error {
+	targets := []*Target{}
 	for remoteURL, destPath := range job.downloadFileMap {
 		url, err := url.Parse(remoteURL)
 		if err != nil {
@@ -380,12 +382,30 @@ func (job *Job) downloadFiles() error {
 			return err
 		}
 
-		err = job.storage.Download(url.Host, url.Path[1:], destPath)
-		if err != nil {
-			return err
+		t := Target{
+			Bucket:    url.Host,
+			Object:    url.Path[1:],
+			LocalPath: destPath,
 		}
+		targets = append(targets, &t)
+		log.WithFields(log.Fields{"target": t}).Debugln("Preparing targets")
 	}
-	return nil
+
+	if job.config.Downloaders < 1 {
+		job.config.Downloaders = 1
+	}
+	downloaders := TargetWorkers{}
+	for i := 0; i < job.config.Downloaders; i++ {
+		downloader := &TargetWorker{
+			name: "upload",
+			impl: job.storage.Download,
+		}
+		downloaders = append(downloaders, downloader)
+	}
+	log.WithFields(log.Fields{"downloaders": len(downloaders)}).Debugln("Downloaders are running")
+
+	err := downloaders.process(targets)
+	return err
 }
 
 func (job *Job) execute() error {

--- a/job_setup_download_files_test.go
+++ b/job_setup_download_files_test.go
@@ -46,6 +46,7 @@ func TestJobSetupCase1(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err := job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -102,6 +103,7 @@ func TestJobSetupCase2(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err := job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -180,6 +182,7 @@ func TestJobSetupCase3(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, attrs["foo"], val)
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -259,6 +262,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, attrs["foo"], val)
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -301,6 +305,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 		downloads_dir: downloads_dir,
 		uploads_dir:   uploads_dir,
 	}
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -344,6 +349,7 @@ func TestJobSetupCaseWithCommandOptions(t *testing.T) {
 		uploads_dir:   uploads_dir,
 	}
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 
@@ -401,6 +407,7 @@ func TestJobSetupWithUseDataAsAttributes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, url1, job.message.raw.Message.Attributes["foo"])
 
+	job.remoteDownloadFiles = job.message.DownloadFiles()
 	err = job.setupDownloadFiles()
 	assert.NoError(t, err)
 

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -13,6 +13,7 @@ type (
 		Pull(subscription string, pullrequest *pubsub.PullRequest) (*pubsub.PullResponse, error)
 		Acknowledge(subscription, ackId string) (*pubsub.Empty, error)
 		ModifyAckDeadline(subscription string, ackIds []string, ackDeadlineSeconds int64) (*pubsub.Empty, error)
+		Get(subscription string) (*pubsub.Subscription, error)
 	}
 
 	pubsubPuller struct {
@@ -39,13 +40,17 @@ func (pp *pubsubPuller) ModifyAckDeadline(subscription string, ackIds []string, 
 	return pp.subscriptionsService.ModifyAckDeadline(subscription, req).Do()
 }
 
+func (pp *pubsubPuller) Get(subscription string) (*pubsub.Subscription, error) {
+	return pp.subscriptionsService.Get(subscription).Do()
+}
+
 type JobConfig struct {
 	Subscription string              `json:"subscription,omitempty"`
 	PullInterval int                 `json:"pull_interval,omitempty"`
 	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
 }
 
-func (c *JobConfig) setupSustainer(service *pubsub.Service) error {
+func (c *JobConfig) setupSustainer(puller Puller) error {
 	flds := log.Fields{"subscription": c.Subscription}
 	if c.Sustainer != nil {
 		cs := c.Sustainer
@@ -59,8 +64,7 @@ func (c *JobConfig) setupSustainer(service *pubsub.Service) error {
 		c.Sustainer = &JobSustainerConfig{}
 	}
 
-	srv := service.Projects.Subscriptions
-	subscription, err := srv.Get(c.Subscription).Do()
+	subscription, err := puller.Get(c.Subscription)
 	if err != nil {
 		flds["error"] = err
 		log.WithFields(flds).Errorln("Failed to get subscription")

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -39,18 +39,16 @@ func (pp *pubsubPuller) ModifyAckDeadline(subscription string, ackIds []string, 
 	return pp.subscriptionsService.ModifyAckDeadline(subscription, req).Do()
 }
 
-type (
-	JobConfig struct {
-		Subscription string              `json:"subscription,omitempty"`
-		PullInterval int                 `json:"pull_interval,omitempty"`
-		Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
-	}
+type JobConfig struct {
+	Subscription string              `json:"subscription,omitempty"`
+	PullInterval int                 `json:"pull_interval,omitempty"`
+	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
+}
 
-	JobSubscription struct {
-		config *JobConfig
-		puller Puller
-	}
-)
+type JobSubscription struct {
+	config *JobConfig
+	puller Puller
+}
 
 func (s *JobSubscription) listen(f func(*JobMessage) error) error {
 	for {

--- a/job_subscription_test.go
+++ b/job_subscription_test.go
@@ -10,7 +10,7 @@ import (
 
 type DummyPullerForJobSubscription struct {
 	callCount int
-	result *pubsub.Subscription
+	result    *pubsub.Subscription
 }
 
 func (p *DummyPullerForJobSubscription) Pull(subscription string, pullrequest *pubsub.PullRequest) (*pubsub.PullResponse, error) {
@@ -29,12 +29,12 @@ func (p *DummyPullerForJobSubscription) Get(subscription string) (*pubsub.Subscr
 
 func TestJobConfigSetupSustainer(t *testing.T) {
 	puller := &DummyPullerForJobSubscription{}
-	
+
 	jc := &JobConfig{
 		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
 		PullInterval: 10,
 		Sustainer: &JobSustainerConfig{
-			Delay: 600,
+			Delay:    600,
 			Interval: 480,
 		},
 	}

--- a/job_subscription_test.go
+++ b/job_subscription_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"testing"
+
+	pubsub "google.golang.org/api/pubsub/v1"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type DummyPullerForJobSubscription struct {
+	callCount int
+	result *pubsub.Subscription
+}
+
+func (p *DummyPullerForJobSubscription) Pull(subscription string, pullrequest *pubsub.PullRequest) (*pubsub.PullResponse, error) {
+	return nil, nil
+}
+func (p *DummyPullerForJobSubscription) Acknowledge(subscription, ackId string) (*pubsub.Empty, error) {
+	return nil, nil
+}
+func (p *DummyPullerForJobSubscription) ModifyAckDeadline(subscription string, ackIds []string, ackDeadlineSeconds int64) (*pubsub.Empty, error) {
+	return nil, nil
+}
+func (p *DummyPullerForJobSubscription) Get(subscription string) (*pubsub.Subscription, error) {
+	p.callCount++
+	return p.result, nil
+}
+
+func TestJobConfigSetupSustainer(t *testing.T) {
+	puller := &DummyPullerForJobSubscription{}
+	
+	jc := &JobConfig{
+		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
+		PullInterval: 10,
+		Sustainer: &JobSustainerConfig{
+			Delay: 600,
+			Interval: 480,
+		},
+	}
+	jc.setupSustainer(puller)
+	assert.Equal(t, 0, puller.callCount)
+
+	// Delay was 0
+	puller = &DummyPullerForJobSubscription{
+		result: &pubsub.Subscription{AckDeadlineSeconds: 300},
+	}
+	jc = &JobConfig{
+		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
+		PullInterval: 10,
+		Sustainer: &JobSustainerConfig{
+			//Delay: 600,
+			Interval: 480,
+		},
+	}
+	jc.setupSustainer(puller)
+	assert.Equal(t, 1, puller.callCount)
+	assert.Equal(t, float64(300), jc.Sustainer.Delay)
+	assert.Equal(t, float64(480), jc.Sustainer.Interval)
+
+	// Interval was 0
+	puller = &DummyPullerForJobSubscription{
+		result: &pubsub.Subscription{AckDeadlineSeconds: 300},
+	}
+	jc = &JobConfig{
+		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
+		PullInterval: 10,
+		Sustainer: &JobSustainerConfig{
+			Delay: 300,
+			// Interval: 480,
+		},
+	}
+	jc.setupSustainer(puller)
+	assert.Equal(t, 1, puller.callCount)
+	assert.Equal(t, float64(300), jc.Sustainer.Delay)
+	assert.Equal(t, float64(240), jc.Sustainer.Interval)
+
+	// No sustainer
+	puller = &DummyPullerForJobSubscription{
+		result: &pubsub.Subscription{AckDeadlineSeconds: 400},
+	}
+	jc = &JobConfig{
+		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
+		PullInterval: 10,
+	}
+	jc.setupSustainer(puller)
+	assert.Equal(t, 1, puller.callCount)
+	assert.Equal(t, float64(400), jc.Sustainer.Delay)
+	assert.Equal(t, float64(320), jc.Sustainer.Interval)
+}

--- a/process.go
+++ b/process.go
@@ -113,6 +113,13 @@ func (p *Process) setup() error {
 		return err
 	}
 
+	err = p.config.Job.setupSustainer(pubsubService)
+	if err != nil {
+		logAttrs := log.Fields{"client": client, "error": err}
+		log.WithFields(logAttrs).Fatalln("Failed to setup sustainer")
+		return err
+	}
+
 	p.subscription = &JobSubscription{
 		config: p.config.Job,
 		puller: &pubsubPuller{pubsubService.Projects.Subscriptions},

--- a/process.go
+++ b/process.go
@@ -113,7 +113,9 @@ func (p *Process) setup() error {
 		return err
 	}
 
-	err = p.config.Job.setupSustainer(pubsubService)
+	puller := &pubsubPuller{pubsubService.Projects.Subscriptions}
+
+	err = p.config.Job.setupSustainer(puller)
 	if err != nil {
 		logAttrs := log.Fields{"client": client, "error": err}
 		log.WithFields(logAttrs).Fatalln("Failed to setup sustainer")
@@ -122,7 +124,7 @@ func (p *Process) setup() error {
 
 	p.subscription = &JobSubscription{
 		config: p.config.Job,
-		puller: &pubsubPuller{pubsubService.Projects.Subscriptions},
+		puller: puller,
 	}
 	p.notification = &ProgressNotification{
 		config:    p.config.Progress,

--- a/test/full.json
+++ b/test/full.json
@@ -5,6 +5,7 @@
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
     },
     "dryrun": true,
+    "downloaders": 5,
     "uploaders": 8
   },
   "job": {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.0"
+const VERSION = "0.5.1-alpha1"


### PR DESCRIPTION
This PR depends on #38 , see https://github.com/groovenauts/blocks-gcs-proxy/compare/5418c97...features/automatic_sustainer_config for actual differences.

When the time to process a message is longer than the subscription's `AckDeadline`, sustainer keeps sending modifyAckDeadline to `pubsub`.
If you forget setting longer `delay` and `interval` than actual subscription's `AckDeadline`, `pubsub` delivers the message repeatedly  even if the message is proceeded successfully.

To prevent this, `blocks-gcs-proxy` sets valid `delay` and `interval` automatically when there's no`sustainer` configuration.
`delay` will be the same value as `AckDeadline`, `interval` will be the 80% of `AckDeadline`.
