### PR TITLE
Sleep only when no message is received

### DIFF
--- a/job_subscription.go
+++ b/job_subscription.go
@@ -94,21 +94,23 @@ type JobSubscription struct {
 
 func (s *JobSubscription) listen(f func(*JobMessage) error) error {
 	for {
-		err := s.process(f)
+		executed, err := s.process(f)
 		if err != nil {
 			return err
 		}
-		time.Sleep(time.Duration(s.config.PullInterval) * time.Second)
+		if !executed {
+			time.Sleep(time.Duration(s.config.PullInterval) * time.Second)
+		}
 	}
 }
 
-func (s *JobSubscription) process(f func(*JobMessage) error) error {
+func (s *JobSubscription) process(f func(*JobMessage) error) (bool, error) {
 	msg, err := s.waitForMessage()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if msg == nil {
-		return nil
+		return false, nil
 	}
 
 	log.WithFields(log.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message}).Infoln("Message received")
@@ -121,7 +123,7 @@ func (s *JobSubscription) process(f func(*JobMessage) error) error {
 		status: running,
 	}
 
-	return f(jobMsg)
+	return true, f(jobMsg)
 }
 
 func (s *JobSubscription) waitForMessage() (*pubsub.ReceivedMessage, error) {

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -136,6 +136,9 @@ func (s *JobSubscription) waitForMessage() (*pubsub.ReceivedMessage, error) {
 		log.WithFields(log.Fields{"subscription": s.config.Subscription, "error": err}).Errorln("Failed to pull")
 		return nil, err
 	}
+	if res == nil {
+		return nil, nil
+	}
 	if len(res.ReceivedMessages) == 0 {
 		return nil, nil
 	}

--- a/job_subscription_test.go
+++ b/job_subscription_test.go
@@ -88,3 +88,81 @@ func TestJobConfigSetupSustainer(t *testing.T) {
 	assert.Equal(t, float64(400), jc.Sustainer.Delay)
 	assert.Equal(t, float64(320), jc.Sustainer.Interval)
 }
+
+
+type DummyPuller struct {
+	responses []*pubsub.PullResponse
+}
+
+func (p *DummyPuller) Pull(subscription string, pullrequest *pubsub.PullRequest) (*pubsub.PullResponse, error) {
+	if len(p.responses) > 0 {
+		res := p.responses[0]
+		p.responses = p.responses[1:]
+		return res, nil
+	} else {
+		return nil, nil
+	}
+}
+func (p *DummyPuller) Acknowledge(subscription, ackId string) (*pubsub.Empty, error) {
+	return nil, nil
+}
+func (p *DummyPuller) ModifyAckDeadline(subscription string, ackIds []string, ackDeadlineSeconds int64) (*pubsub.Empty, error) {
+	return nil, nil
+}
+func (p *DummyPuller) Get(subscription string) (*pubsub.Subscription, error) {
+	return nil, nil
+}
+
+func TestJobSubscriptionProcess(t *testing.T) {
+	puller := &DummyPuller{
+		responses: []*pubsub.PullResponse{
+			&pubsub.PullResponse{
+				ReceivedMessages: []*pubsub.ReceivedMessage{
+					&pubsub.ReceivedMessage{
+						AckId: "dummy-ack-id1",
+						Message: &pubsub.PubsubMessage{
+							Attributes: map[string]string {
+								"foo": "A",
+							},
+							MessageId: "dummy-msg-id1",
+						},
+					},
+				},
+			},
+			&pubsub.PullResponse{
+				ReceivedMessages: []*pubsub.ReceivedMessage{},
+			},
+		},
+	}
+
+	jc := &JobConfig{
+		Subscription: "projects/dummy-proj-999/subscriptions/test01-job-subscription",
+		PullInterval: 10,
+		Sustainer: &JobSustainerConfig{
+			Delay:    600,
+			Interval: 480,
+		},
+	}
+	jc.setupSustainer(puller)
+
+	s := &JobSubscription{
+		config: jc,
+		puller: puller,
+	}
+
+	f := func(msg *JobMessage) error {
+		return nil
+	}
+	// MessageId: dummy-msg-id1
+	executed, error := s.process(f)
+	assert.True(t, executed)
+	assert.NoError(t, error)
+	// PullResponse is returned but any ReceivedMessage doesn't exist
+	executed, error = s.process(f)
+	assert.False(t, executed)
+	assert.NoError(t, error)
+	// PullResponse isn't returned
+	executed, error = s.process(f)
+	assert.False(t, executed)
+	assert.NoError(t, error)
+}

--- a/job_subscription_test.go
+++ b/job_subscription_test.go
@@ -89,7 +89,6 @@ func TestJobConfigSetupSustainer(t *testing.T) {
 	assert.Equal(t, float64(320), jc.Sustainer.Interval)
 }
 
-
 type DummyPuller struct {
 	responses []*pubsub.PullResponse
 }
@@ -121,7 +120,7 @@ func TestJobSubscriptionProcess(t *testing.T) {
 					&pubsub.ReceivedMessage{
 						AckId: "dummy-ack-id1",
 						Message: &pubsub.PubsubMessage{
-							Attributes: map[string]string {
+							Attributes: map[string]string{
 								"foo": "A",
 							},
 							MessageId: "dummy-msg-id1",

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.2"
+const VERSION = "0.5.3"


### PR DESCRIPTION
This is an implementation for #42 .

Now `blocks-gcs-proxy` always sleeps after it process a message.
When there're a lot of messages, `blocks-gcs-proxy` shouldn't sleep but process the next message.
So this PR modifies `blocks-gcs-proxy` to sleep only when it receives no message.

