### PR TITLE
Progress log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /config.yml
 /vendor
 /blocks-gcs-proxy
+/config.json

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ specified by `job.subscription` in `config.json`.
 | log       | map    | False | |
 | log.level | string | False | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
 | command   | map | False |  |
-| command.dryrun | bool | False | |
+| command.dryrun | bool | False | Don't run the command if this is true. |
 | command.downloaders | int | False | The number of thread to download. Default: 1.|
 | command.uploaders | int | False | The number of thread to upload. Default: 1.|
 | command.options | map[key][]string | False | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |

--- a/README.md
+++ b/README.md
@@ -84,3 +84,58 @@ you can choose which command is executed by message attribute named `foo` at run
 | `{"foo": "key2"}`  | `cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}` |
 
 If the attribute value is not defined in commands keys, the message is ignored with error message.
+
+## blocks-gcs-proxy check
+
+Check the `config.json` is valid.
+You can give other file with `--config` or `-c` option.
+
+```bash
+$ ./blocks-gcs-proxy check -c config2.json
+Error to load config.json.bak cause of invalid character '}' looking for beginning of object key string
+```
+
+
+## blocks-gcs-proxy download
+
+```bash
+NAME:
+   blocks-gcs-proxy download - Download the files from GCS to downloads directory
+
+USAGE:
+   blocks-gcs-proxy download [command options] [arguments...]
+
+OPTIONS:
+   --downloads_dir value, -d value  Path to the directory which has bucket_name/path/to/file
+   --downloaders value, -n value    Number of downloaders (default: 6)
+$ ./blocks-gcs-proxy download --help
+
+```
+
+### Example
+
+```bash
+$ ./blocks-gcs-proxy download -d tmp/downloads -n 5 gs://bucket1/path/to/file1  gs://bucket1/path/to/file2  gs://bucket1/path/to/file3
+```
+
+
+## blocks-gcs-proxy upload
+
+```bash
+$ ./blocks-gcs-proxy upload --help
+NAME:
+   blocks-gcs-proxy upload - Upload the files under uploads directory
+
+USAGE:
+   blocks-gcs-proxy upload [command options] [arguments...]
+
+OPTIONS:
+   --uploads_dir value, -d value  Path to the directory which has bucket_name/path/to/file
+   --uploaders value, -n value    Number of uploaders (default: 6)
+```
+
+### Example
+
+```bash
+$ ./blocks-gcs-proxy upload -d tmp/uploads -n 5
+```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,75 @@ Download the file from https://github.com/groovenauts/blocks-gcs-proxy/releases 
 
 ## Usage
 
+Create `config.json` like this:
+
+```json
+{
+  "job": {
+    "subscription": "projects/proj-dummy-999/subscriptions/pipeline01-job-subscription"
+  },
+  "progress": {
+    "topic": "projects/proj-dummy-999/topics/pipeline01-progress-topic"
+  }
+}
 ```
-blocks-gcs-proxy ARGS...
+
+Run `blocks-gcs-proxy` with command
+
 ```
+blocks-gcs-proxy COMMAND ARGS...
+```
+
+`blocks-gcs-proxy` calls `COMMAND` with `ARGS` for each message from Pubsub subscription
+specified by `job.subscription` in `config.json`.
+
+## config.json
+
+| Key     | Type | Required | Description  |
+|---------|------|----------|--------------|
+| job     | map | True |   |
+| job.subscription | string | True | The subscription name to pull job messages |
+| job.pull_interval | int | False | The interval time in second to pull when it gets no job message. Default 0 |
+| job.sustainer     | map | False |
+| job.sustainer.delay | int | False | The new deadline in second to extend deadline to ack |
+| job.sustainer.interval | int | False | The interval in second to send the message which extends deadline to ack |
+| progress | map | True |
+| progress.topic | string | True | The topic name to publish job progress messages |
+| progress.level | string | False | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
+| log       | map    | False | |
+| log.level | string | False | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
+| command   | map | False |  |
+| command.dryrun | bool | False | |
+| command.downloaders | int | False | The number of thread to download. Default: 1.|
+| command.uploaders | int | False | The number of thread to upload. Default: 1.|
+| command.options | map[key][]string | False | Define if you have to run one of multiple command. See [Multiple command options] for more detail/ |
+
+
+### Multiple command options
+
+If you have commands data in your config.json like the following:
+
+```json
+{
+  "commands": {
+    "options": {
+      "key1": ["cmd1", "%{download_files}"],
+      "key2": ["cmd2", "%{download_files.bar}", "%{uploads_dir}", "%{download_files.baz}"]
+    }
+  }
+}
+```
+
+And when you run the command by
+```
+$ bundle exec magellan-gcs-proxy %{attrs.foo}
+```
+
+you can choose which command is executed by message attribute named `foo` at runtime.
+
+| message attributes | command `magellan-gcs-proxy` calls  |
+|--------------------|----------------------|
+| `{"foo": "key1"}`  | `cmd1 %{download_files}` |
+| `{"foo": "key2"}`  | `cmd2 %{download_files.bar} %{uploads_dir} %{download_files.baz}` |
+
+If the attribute value is not defined in commands keys, the message is ignored with error message.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ specified by `job.subscription` in `config.json`.
 | command.dryrun | bool | False | |
 | command.downloaders | int | False | The number of thread to download. Default: 1.|
 | command.uploaders | int | False | The number of thread to upload. Default: 1.|
-| command.options | map[key][]string | False | Define if you have to run one of multiple command. See [Multiple command options] for more detail/ |
+| command.options | map[key][]string | False | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
 
 
 ### Multiple command options

--- a/cli.go
+++ b/cli.go
@@ -36,7 +36,7 @@ func main() {
 		},
 		{
 			Name:  "download",
-			Usage: "Download the files under downloads directory",
+			Usage: "Download the files from GCS to downloads directory",
 			Action: func(c *cli.Context) error {
 				config := &ProcessConfig{}
 				config.Log = &LogConfig{Level: "debug"}

--- a/job_message.go
+++ b/job_message.go
@@ -199,7 +199,7 @@ func (m *JobMessage) waitAndSendMAD(notification *ProgressNotification, nextLimi
 		log.WithFields(logAttrs).Errorln("waitAndSendMAD ModifyAckDeadline")
 		msg := fmt.Sprintf("Failed modifyAckDeadline %v, %v, %v cause of %v\n", m.sub, m.raw.AckId, m.config.Delay, err)
 		log.WithFields(logAttrs).Fatalf(msg)
-		notification.notifyProgress(m.MessageId(), WORKING, false, "error", msg)
+		notification.notifyProgress(m.MessageId(), WORKING, false, log.ErrorLevel, msg)
 	}
 	return nil
 }

--- a/job_step.go
+++ b/job_step.go
@@ -4,7 +4,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-
 type JobStepStatus int
 
 const (

--- a/job_step.go
+++ b/job_step.go
@@ -25,6 +25,7 @@ type (
 	JobStep    int
 	JobStepDef struct {
 		name            string
+		successLogLevel string
 		failureLogLevel string
 		baseProgress    Progress
 	}
@@ -43,19 +44,22 @@ const (
 
 var (
 	JOB_STEP_DEFS = map[JobStep]JobStepDef{
-		INITIALIZING: JobStepDef{"INITIALIZING", "error", PREPARING},
-		DOWNLOADING:  JobStepDef{"DOWNLOADING", "error", WORKING},
-		EXECUTING:    JobStepDef{"EXECUTING", "error", WORKING},
-		UPLOADING:    JobStepDef{"UPLOADING", "error", WORKING},
-		CLEANUP:      JobStepDef{"CLEANUP", "warn", WORKING},
-		NACKSENDING:  JobStepDef{"NACKSENDING", "warn", RETRYING},
-		CANCELLING:   JobStepDef{"CANCELLING", "fatal", INVALID_JOB},
-		ACKSENDING:   JobStepDef{"ACKSENDING", "fatal", COMPLETED},
+		INITIALIZING: JobStepDef{"INITIALIZING", "info", "error", PREPARING},
+		DOWNLOADING:  JobStepDef{"DOWNLOADING", "debug", "error", WORKING},
+		EXECUTING:    JobStepDef{"EXECUTING", "debug", "error", WORKING},
+		UPLOADING:    JobStepDef{"UPLOADING", "debug", "error", WORKING},
+		CLEANUP:      JobStepDef{"CLEANUP", "debug", "warn", WORKING},
+		NACKSENDING:  JobStepDef{"NACKSENDING", "warn", "error", RETRYING},
+		CANCELLING:   JobStepDef{"CANCELLING", "error", "fatal", INVALID_JOB},
+		ACKSENDING:   JobStepDef{"ACKSENDING", "info", "fatal", COMPLETED},
 	}
 )
 
 func (js JobStep) String() string {
 	return JOB_STEP_DEFS[js].name
+}
+func (js JobStep) successLogLevel() string {
+	return JOB_STEP_DEFS[js].successLogLevel
 }
 func (js JobStep) failureLogLevel() string {
 	return JOB_STEP_DEFS[js].failureLogLevel
@@ -69,8 +73,10 @@ func (js JobStep) completed(st JobStepStatus) bool {
 }
 func (js JobStep) logLevelFor(st JobStepStatus) string {
 	switch st {
-	// case STARTING: return "info"
-	// case SUCCESS: return js.successLogLevel()
+	case STARTING:
+		return "debug"
+	case SUCCESS:
+		return js.successLogLevel()
 	case FAILURE:
 		return js.failureLogLevel()
 	default:

--- a/job_step.go
+++ b/job_step.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	log "github.com/Sirupsen/logrus"
+)
+
+
 type JobStepStatus int
 
 const (
@@ -25,8 +30,8 @@ type (
 	JobStep    int
 	JobStepDef struct {
 		name            string
-		successLogLevel string
-		failureLogLevel string
+		successLogLevel log.Level
+		failureLogLevel log.Level
 		baseProgress    Progress
 	}
 )
@@ -44,24 +49,24 @@ const (
 
 var (
 	JOB_STEP_DEFS = map[JobStep]JobStepDef{
-		INITIALIZING: JobStepDef{"INITIALIZING", "info", "error", PREPARING},
-		DOWNLOADING:  JobStepDef{"DOWNLOADING", "debug", "error", WORKING},
-		EXECUTING:    JobStepDef{"EXECUTING", "debug", "error", WORKING},
-		UPLOADING:    JobStepDef{"UPLOADING", "debug", "error", WORKING},
-		CLEANUP:      JobStepDef{"CLEANUP", "debug", "warn", WORKING},
-		NACKSENDING:  JobStepDef{"NACKSENDING", "warn", "error", RETRYING},
-		CANCELLING:   JobStepDef{"CANCELLING", "error", "fatal", INVALID_JOB},
-		ACKSENDING:   JobStepDef{"ACKSENDING", "info", "fatal", COMPLETED},
+		INITIALIZING: JobStepDef{"INITIALIZING", log.InfoLevel, log.ErrorLevel, PREPARING},
+		DOWNLOADING:  JobStepDef{"DOWNLOADING", log.DebugLevel, log.ErrorLevel, WORKING},
+		EXECUTING:    JobStepDef{"EXECUTING", log.DebugLevel, log.ErrorLevel, WORKING},
+		UPLOADING:    JobStepDef{"UPLOADING", log.DebugLevel, log.ErrorLevel, WORKING},
+		CLEANUP:      JobStepDef{"CLEANUP", log.DebugLevel, log.WarnLevel, WORKING},
+		NACKSENDING:  JobStepDef{"NACKSENDING", log.WarnLevel, log.ErrorLevel, RETRYING},
+		CANCELLING:   JobStepDef{"CANCELLING", log.ErrorLevel, log.FatalLevel, INVALID_JOB},
+		ACKSENDING:   JobStepDef{"ACKSENDING", log.InfoLevel, log.FatalLevel, COMPLETED},
 	}
 )
 
 func (js JobStep) String() string {
 	return JOB_STEP_DEFS[js].name
 }
-func (js JobStep) successLogLevel() string {
+func (js JobStep) successLogLevel() log.Level {
 	return JOB_STEP_DEFS[js].successLogLevel
 }
-func (js JobStep) failureLogLevel() string {
+func (js JobStep) failureLogLevel() log.Level {
 	return JOB_STEP_DEFS[js].failureLogLevel
 }
 func (js JobStep) baseProgress() Progress {
@@ -71,16 +76,16 @@ func (js JobStep) baseProgress() Progress {
 func (js JobStep) completed(st JobStepStatus) bool {
 	return (js == ACKSENDING) && (st == SUCCESS)
 }
-func (js JobStep) logLevelFor(st JobStepStatus) string {
+func (js JobStep) logLevelFor(st JobStepStatus) log.Level {
 	switch st {
 	case STARTING:
-		return "debug"
+		return log.DebugLevel
 	case SUCCESS:
 		return js.successLogLevel()
 	case FAILURE:
 		return js.failureLogLevel()
 	default:
-		return "info"
+		return log.InfoLevel
 	}
 }
 func (js JobStep) progressFor(st JobStepStatus) Progress {

--- a/process.go
+++ b/process.go
@@ -127,9 +127,7 @@ func (p *Process) setup() error {
 		puller: puller,
 	}
 
-	if p.config.Progress.LogLevel == "" {
-		p.config.Progress.LogLevel = log.InfoLevel.String()
-	}
+	p.config.Progress.setup()
 	level, err := log.ParseLevel(p.config.Progress.LogLevel)
 	if err != nil {
 		logAttrs := log.Fields{"log_level": p.config.Progress.LogLevel}

--- a/process.go
+++ b/process.go
@@ -137,7 +137,7 @@ func (p *Process) setup() error {
 	p.notification = &ProgressNotification{
 		config:    p.config.Progress,
 		publisher: &pubsubPublisher{pubsubService.Projects.Topics},
-		logLevel: level,
+		logLevel:  level,
 	}
 	return nil
 }

--- a/process.go
+++ b/process.go
@@ -126,9 +126,20 @@ func (p *Process) setup() error {
 		config: p.config.Job,
 		puller: puller,
 	}
+
+	if p.config.Progress.LogLevel == "" {
+		p.config.Progress.LogLevel = log.InfoLevel.String()
+	}
+	level, err := log.ParseLevel(p.config.Progress.LogLevel)
+	if err != nil {
+		logAttrs := log.Fields{"log_level": p.config.Progress.LogLevel}
+		log.WithFields(logAttrs).Fatalln("Failed to parse log_level")
+		return err
+	}
 	p.notification = &ProgressNotification{
 		config:    p.config.Progress,
 		publisher: &pubsubPublisher{pubsubService.Projects.Topics},
+		logLevel: level,
 	}
 	return nil
 }

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -41,12 +41,14 @@ const (
 
 type (
 	ProgressConfig struct {
-		Topic string `json:"topic"`
+		Topic    string `json:"topic"`
+		LogLevel string `json:"log_level"`
 	}
 
 	ProgressNotification struct {
 		config    *ProgressConfig
 		publisher Publisher
+		logLevel  log.Level
 	}
 )
 

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -79,7 +79,11 @@ func (pn *ProgressNotification) notifyWithMessage(job_msg_id string, step JobSte
 }
 
 func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progress, completed bool, level log.Level, data string) error {
-
+	// https://godoc.org/github.com/sirupsen/logrus#Level
+	// log.InfoLevel < log.DebugLevel => true
+	if pn.logLevel < level {
+		return nil
+	}
 	opts := map[string]string{
 		"progress":       strconv.Itoa(int(progress)),
 		"completed":      strconv.FormatBool(completed),

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -72,12 +72,13 @@ func (pn *ProgressNotification) notifyWithMessage(job_msg_id string, step JobSte
 	return pn.notifyProgress(job_msg_id, step.progressFor(st), step.completed(st), step.logLevelFor(st), msg)
 }
 
-func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progress, completed bool, level, data string) error {
+func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progress, completed bool, level log.Level, data string) error {
+
 	opts := map[string]string{
 		"progress":       strconv.Itoa(int(progress)),
 		"completed":      strconv.FormatBool(completed),
 		"job_message_id": job_msg_id,
-		"level":          level,
+		"level":          level.String(),
 	}
 	logAttrs := log.Fields{}
 	for k, v := range opts {

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -39,18 +39,16 @@ const (
 	COMPLETED
 )
 
-type (
-	ProgressConfig struct {
-		Topic    string `json:"topic"`
-		LogLevel string `json:"log_level"`
-	}
+type ProgressConfig struct {
+	Topic    string `json:"topic"`
+	LogLevel string `json:"log_level"`
+}
 
-	ProgressNotification struct {
-		config    *ProgressConfig
-		publisher Publisher
-		logLevel  log.Level
-	}
-)
+type ProgressNotification struct {
+	config    *ProgressConfig
+	publisher Publisher
+	logLevel  log.Level
+}
 
 func (pn *ProgressNotification) wrap(msg_id string, step JobStep, f func() error) func() error {
 	return func() error {

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -44,6 +44,12 @@ type ProgressConfig struct {
 	LogLevel string `json:"log_level"`
 }
 
+func (c *ProgressConfig) setup() {
+	if c.LogLevel == "" {
+		c.LogLevel = log.InfoLevel.String()
+	}
+}
+
 type ProgressNotification struct {
 	config    *ProgressConfig
 	publisher Publisher

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -41,7 +41,7 @@ const (
 
 type (
 	ProgressConfig struct {
-		Topic string
+		Topic string `json:"topic"`
 	}
 
 	ProgressNotification struct {

--- a/test/full.json
+++ b/test/full.json
@@ -17,7 +17,8 @@
     }
   },
   "progress": {
-    "topic": "projects/dummy-gcp-proj/topics/test-progress-topic"
+    "topic": "projects/dummy-gcp-proj/topics/test-progress-topic",
+    "log_level": "info"
   },
   "log": {
     "level": "debug"

--- a/test/minimum.json
+++ b/test/minimum.json
@@ -1,0 +1,8 @@
+{
+  "job": {
+    "subscription": "projects/proj-dummy-999/subscriptions/pipeline01-job-subscription"
+  },
+  "progress": {
+    "topic": "projects/proj-dummy-999/topics/pipeline01-progress-topic"
+  }
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.3"
+const VERSION = "0.5.4"


### PR DESCRIPTION
This PR is for #43 .

Add `progress.log_level` to reduce the number of progress messages.
The log levels are defined at https://github.com/groovenauts/blocks-gcs-proxy/blob/features/progress_log_level/job_step.go#L50-L59.

## Changes

- Define [successLogLevel for each JobStep](https://github.com/groovenauts/blocks-gcs-proxy/blob/features/progress_log_level/job_step.go#L50-L59 )
- Use `logrus.Level` instead of string
- Don't publish progress messages which has higher log level than `progress.log_level` in `config.json`
- Update [README.md](https://github.com/groovenauts/blocks-gcs-proxy/blob/features/progress_log_level/README.md)
