### PR TITLE
Fix dryrun and some default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ you can choose which command is executed by message attribute named `foo` at run
 
 If the attribute value is not defined in commands keys, the message is ignored with error message.
 
+
+### Sustainer
+
+When your command takes longer time than `AckDeadline` of the pipeline job subscription,
+Sustainer sends requests to the subscription to expand the deadline.
+If you don't set `job.sustainer` in your `config.json`, `blocks-gcs-proxy` sets them
+from the subscription's `AckDeadline`.
+
+| Key                    | Default   |
+|------------------------|-----------|
+| job.sustainer.delay    | Subscription's `AckDeadline` |
+| job.sustainer.interval | Subscription's `AckDeadline` * 0.8 |
+
+
 ## blocks-gcs-proxy check
 
 Check the `config.json` is valid.
@@ -139,15 +153,3 @@ OPTIONS:
 ```bash
 $ ./blocks-gcs-proxy upload -d tmp/uploads -n 5
 ```
-
-## Sustainer
-
-When your command takes longer time than `AckDeadline` of the pipeline job subscription,
-Sustainer sends requests to the subscription to expand the deadline.
-If you don't set `job.sustainer` in your `config.json`, `blocks-gcs-proxy` sets them
-from the subscription's `AckDeadline`.
-
-| Key                    | Default   |
-|------------------------|-----------|
-| job.sustainer.delay    | Subscription's `AckDeadline` |
-| job.sustainer.interval | Subscription's `AckDeadline` * 0.8 |

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ specified by `job.subscription` in `config.json`.
 | job.subscription | string | True | - | The subscription name to pull job messages |
 | job.pull_interval | int | False | 10 | The interval time in second to pull when it gets no job message. |
 | job.sustainer     | map | False |  |  |
-| job.sustainer.delay | int | False | *1 | The new deadline in second to extend deadline to ack |
-| job.sustainer.interval | int | False | *1 | The interval in second to send the message which extends deadline to ack |
+| job.sustainer.delay | int | False | See [Sustainer](#sustainer) | The new deadline in second to extend deadline to ack |
+| job.sustainer.interval | int | False | See [Sustainer](#sustainer) | The interval in second to send the message which extends deadline to ack |
 | progress | map | True |  |  |
 | progress.topic | string | True | - | The topic name to publish job progress messages |
 | progress.level | string | False | `info` | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
@@ -139,3 +139,15 @@ OPTIONS:
 ```bash
 $ ./blocks-gcs-proxy upload -d tmp/uploads -n 5
 ```
+
+## Sustainer
+
+When your command takes longer time than `AckDeadline` of the pipeline job subscription,
+Sustainer sends requests to the subscription to expand the deadline.
+If you don't set `job.sustainer` in your `config.json`, `blocks-gcs-proxy` sets them
+from the subscription's `AckDeadline`.
+
+| Key                    | Default   |
+|------------------------|-----------|
+| job.sustainer.delay    | Subscription's `AckDeadline` |
+| job.sustainer.interval | Subscription's `AckDeadline` * 0.8 |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ specified by `job.subscription` in `config.json`.
 ## config.json
 
 | Key     | Type | Required | Default | Description  |
-|---------|------|----------|--------------|
+|---------|------|----------|---------|---------------|
 | job     | map | True |  |  |
 | job.subscription | string | True | - | The subscription name to pull job messages |
 | job.pull_interval | int | False | 10 | The interval time in second to pull when it gets no job message. |

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ specified by `job.subscription` in `config.json`.
 
 ## config.json
 
-| Key     | Type | Required | Description  |
+| Key     | Type | Required | Default | Description  |
 |---------|------|----------|--------------|
-| job     | map | True |   |
-| job.subscription | string | True | The subscription name to pull job messages |
-| job.pull_interval | int | False | The interval time in second to pull when it gets no job message. Default 0 |
-| job.sustainer     | map | False |
-| job.sustainer.delay | int | False | The new deadline in second to extend deadline to ack |
-| job.sustainer.interval | int | False | The interval in second to send the message which extends deadline to ack |
-| progress | map | True |
-| progress.topic | string | True | The topic name to publish job progress messages |
-| progress.level | string | False | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
-| log       | map    | False | |
-| log.level | string | False | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
-| command   | map | False |  |
-| command.dryrun | bool | False | Don't run the command if this is true. |
-| command.downloaders | int | False | The number of thread to download. Default: 1.|
-| command.uploaders | int | False | The number of thread to upload. Default: 1.|
-| command.options | map[key][]string | False | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
+| job     | map | True |  |  |
+| job.subscription | string | True | - | The subscription name to pull job messages |
+| job.pull_interval | int | False | 10 | The interval time in second to pull when it gets no job message. |
+| job.sustainer     | map | False |  |  |
+| job.sustainer.delay | int | False | *1 | The new deadline in second to extend deadline to ack |
+| job.sustainer.interval | int | False | *1 | The interval in second to send the message which extends deadline to ack |
+| progress | map | True |  |  |
+| progress.topic | string | True | - | The topic name to publish job progress messages |
+| progress.level | string | False | `info` | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
+| log       | map    | False |  |  |
+| log.level | string | False | `info` | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
+| command   | map | False |  |  |
+| command.dryrun | bool | False | `false` | Don't run the command if this is true. |
+| command.downloaders | int | False | 1 | The number of thread to download. |
+| command.uploaders | int | False | 1 | The number of thread to upload. |
+| command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
 
 
 ### Multiple command options

--- a/job.go
+++ b/job.go
@@ -332,6 +332,8 @@ func (job *Job) build() error {
 	logAttrs["command"] = values
 	log.WithFields(logAttrs).Debugln("")
 	job.cmd = exec.Command(values[0], values[1:]...)
+	job.cmd.Stdout = os.Stdout
+	job.cmd.Stderr = os.Stderr
 	return nil
 }
 
@@ -409,8 +411,9 @@ func (job *Job) downloadFiles() error {
 }
 
 func (job *Job) execute() error {
-	job.cmd.Stdout = os.Stdout
-	job.cmd.Stderr = os.Stderr
+	if job.config.Dryrun {
+		return nil
+	}
 	log.WithFields(log.Fields{"cmd": job.cmd}).Debugln("EXECUTING")
 	err := job.cmd.Run()
 	if err != nil {

--- a/job.go
+++ b/job.go
@@ -19,32 +19,32 @@ import (
 )
 
 type CommandConfig struct {
-		Template    []string            `json:"-"`
-		Options     map[string][]string `json:"options,omitempty"`
-		Dryrun      bool                `json:"dryrun,omitempty"`
-		Uploaders   int                 `json:"uploaders,omitempty"`
-		Downloaders int                 `json:"downloaders,omitempty"`
-	}
+	Template    []string            `json:"-"`
+	Options     map[string][]string `json:"options,omitempty"`
+	Dryrun      bool                `json:"dryrun,omitempty"`
+	Uploaders   int                 `json:"uploaders,omitempty"`
+	Downloaders int                 `json:"downloaders,omitempty"`
+}
 
 type Job struct {
-		config *CommandConfig
-		// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
-		message      *JobMessage
-		notification *ProgressNotification
-		storage      Storage
+	config *CommandConfig
+	// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
+	message      *JobMessage
+	notification *ProgressNotification
+	storage      Storage
 
-		// These are set at at setupWorkspace
-		workspace     string
-		downloads_dir string
-		uploads_dir   string
+	// These are set at at setupWorkspace
+	workspace     string
+	downloads_dir string
+	uploads_dir   string
 
-		// These are set at setupDownloadFiles
-		downloadFileMap     map[string]string
-		remoteDownloadFiles interface{}
-		localDownloadFiles  interface{}
+	// These are set at setupDownloadFiles
+	downloadFileMap     map[string]string
+	remoteDownloadFiles interface{}
+	localDownloadFiles  interface{}
 
-		cmd *exec.Cmd
-	}
+	cmd *exec.Cmd
+}
 
 func (job *Job) run() error {
 	err := job.runWithoutErrorHandling()

--- a/job.go
+++ b/job.go
@@ -18,8 +18,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-type (
-	CommandConfig struct {
+type CommandConfig struct {
 		Template    []string            `json:"-"`
 		Options     map[string][]string `json:"options,omitempty"`
 		Dryrun      bool                `json:"dryrun,omitempty"`
@@ -27,7 +26,7 @@ type (
 		Downloaders int                 `json:"downloaders,omitempty"`
 	}
 
-	Job struct {
+type Job struct {
 		config *CommandConfig
 		// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
 		message      *JobMessage
@@ -46,7 +45,6 @@ type (
 
 		cmd *exec.Cmd
 	}
-)
 
 func (job *Job) run() error {
 	err := job.runWithoutErrorHandling()

--- a/job.go
+++ b/job.go
@@ -26,6 +26,15 @@ type CommandConfig struct {
 	Downloaders int                 `json:"downloaders,omitempty"`
 }
 
+func (c *CommandConfig) setup() {
+	if c.Downloaders < 1 {
+		c.Downloaders = 1
+	}
+	if c.Uploaders < 1 {
+		c.Uploaders = 1
+	}
+}
+
 type Job struct {
 	config *CommandConfig
 	// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
@@ -390,9 +399,6 @@ func (job *Job) downloadFiles() error {
 		log.WithFields(log.Fields{"target": t}).Debugln("Preparing targets")
 	}
 
-	if job.config.Downloaders < 1 {
-		job.config.Downloaders = 1
-	}
 	downloaders := TargetWorkers{}
 	for i := 0; i < job.config.Downloaders; i++ {
 		downloader := &TargetWorker{
@@ -445,9 +451,6 @@ func (job *Job) uploadFiles() error {
 		log.WithFields(log.Fields{"target": t}).Debugln("Preparing targets")
 	}
 
-	if job.config.Uploaders < 1 {
-		job.config.Uploaders = 1
-	}
 	uploaders := TargetWorkers{}
 	for i := 0; i < job.config.Uploaders; i++ {
 		uploader := &TargetWorker{

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -50,6 +50,12 @@ type JobConfig struct {
 	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
 }
 
+func (c *JobConfig) setup() {
+	if c.PullInterval == 0 {
+		c.PullInterval = 10
+	}
+}
+
 func (c *JobConfig) setupSustainer(puller Puller) error {
 	flds := log.Fields{"subscription": c.Subscription}
 	if c.Sustainer != nil {

--- a/job_test.go
+++ b/job_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,5 +103,30 @@ func TestJobBuildWithInvalidDownloadFilesReference(t *testing.T) {
 		}
 		assert.Regexp(t, "No value found", err.Error())
 		assert.Regexp(t, "download_files", err.Error())
+	}
+}
+
+func TestJobExecuteWithDryrun(t *testing.T) {
+	patterns := []struct {
+		dryrun   bool
+		expected string
+	}{
+		{dryrun: false, expected: "foo\n"},
+		{dryrun: true, expected: ""},
+	}
+	for _, ptn := range patterns {
+		b := new(bytes.Buffer)
+		cmd := exec.Command("echo", "foo")
+		cmd.Stdout = b
+		cmd.Stderr = b
+		job := &Job{
+			cmd: cmd,
+			config: &CommandConfig{
+				Dryrun: ptn.dryrun,
+			},
+		}
+		err := job.execute()
+		assert.NoError(t, err)
+		assert.Equal(t, ptn.expected, b.String())
 	}
 }

--- a/process.go
+++ b/process.go
@@ -30,6 +30,7 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
+	c.Command.setup()
 
 	c.Command.Template = args
 	if c.Job == nil {

--- a/process.go
+++ b/process.go
@@ -30,10 +30,13 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
+
 	c.Command.Template = args
 	if c.Job == nil {
 		c.Job = &JobConfig{}
 	}
+	c.Job.setup()
+
 	if c.Progress == nil {
 		c.Progress = &ProgressConfig{}
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.4"
+const VERSION = "0.5.5"


### PR DESCRIPTION
- Fix job.execute because `command.dryrun ` option was ignored.
- Modify `job.pull_interval` default value from 0 to 10.
- Extract setup `setup` method from each `CommandConfig` and `JobConfig`
- Add default value to `config.json` table in [README.md](https://github.com/groovenauts/blocks-gcs-proxy/blob/fix/dryrun_and_default_values/README.md)
- Add descriptions about Sustainer

