### PR TITLE
Cloud Pub/Sub Notifications support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.bundle/
 /.yardoc
 /Gemfile.lock
 /_yardoc/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
-/.yardoc
-/Gemfile.lock
-/_yardoc/
-/coverage/
 /pkg/
-/spec/reports/
 /tmp/
 /.env
 /config.yml

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ endif
 
 build:
 	mkdir -p ${PKGDIR}
-	for x in "$(OS_LIST)" ; do \
-		gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="$$x" -arch="${ARCH}" ; \
-	done
+	gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="${OS_LIST}" -arch="${ARCH}" ; \
 
 release: build
 	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft ${VERSION} pkg

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 build:
 	mkdir -p ${PKGDIR}
-	gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="${OS_LIST}" -arch="${ARCH}" ; \
+	gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="${OS_LIST}" -arch="${ARCH}"
 
 release: build
 	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft ${VERSION} pkg

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PKGDIR=./pkg
 BASENAME=blocks-gcs-proxy
 VERSION=`grep VERSION version.go | cut -f2 -d\"`
-OS=linux
+OS_LIST=linux darwin
 ARCH=amd64
 UNFORMATTED=$(shell gofmt -l *.go)
 
@@ -28,7 +28,9 @@ endif
 
 build:
 	mkdir -p ${PKGDIR}
-	gox -output="${PKGDIR}/{{.Dir}}_${OS}_${ARCH}" -os="${OS}" -arch="${ARCH}"
+	for x in "$(OS_LIST)" ; do \
+		gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="$$x" -arch="${ARCH}" ; \
+	done
 
 release: build
 	ghr -u groovenauts -r blocks-gcs-proxy --replace --draft ${VERSION} pkg

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you have commands data in your config.json like the following:
 
 And when you run the command by
 ```
-$ bundle exec magellan-gcs-proxy %{attrs.foo}
+$ blocks-gcs-proxy %{attrs.foo}
 ```
 
 you can choose which command is executed by message attribute named `foo` at runtime.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 blocks-gcs-proxy is a proxy for MAGELLAN BLOCKS `concurrent batch board`.
 
+## Features
+
+- [Multiple commands support](#multiple-command-options)
+- [Work with Cloud Pub/Sub Notifications](./doc/pubsub_notification.md)
+
 
 ## Installation
 

--- a/doc/pubsub_notification.md
+++ b/doc/pubsub_notification.md
@@ -17,15 +17,10 @@ run your command.
 ### Create notification config to your bucket
 
 ```
-gsutil notification create -t projects/[Your-Project]/topics/[Your-Pipeline-Job-Topic] -f json gs://[Your-Bucket]
-```
-
-If you need the notification whose `eventType` is `OBJECT_FINALIZE`, you can add `-e OBJECT_FINALIZE` option to the
-above command like this:
-
-```
 gsutil notification create -t projects/[Your-Project]/topics/[Your-Pipeline-Job-Topic] -f json gs://[Your-Bucket] -e OBJECT_FINALIZE
 ```
+
+`blocks-gcs-proxy` doesn't support `OBJECT_DELETE` yet. So dont't forget append `-e OBJECT_FINALIZE`.
 
 You can see other eventTypes at https://cloud.google.com/storage/docs/pubsub-notifications#events .
 Type `gsutil notification create --help` for more detail.

--- a/doc/pubsub_notification.md
+++ b/doc/pubsub_notification.md
@@ -40,6 +40,7 @@ For example, the following command shows you them.
 
 ```
 $ blocks-gcs-proxy echo "%{attrs.eventType}" "%{attrs.bucketId}" "%{attrs.objectId}"
+```
 
 You can see other attributes at https://cloud.google.com/storage/docs/pubsub-notifications#format .
 

--- a/doc/pubsub_notification.md
+++ b/doc/pubsub_notification.md
@@ -1,0 +1,54 @@
+# Use blocks-gcs-proxy with Cloud Pub/Sub Notifications
+
+## Overview
+
+If you run your containers after a file uploaded to the specified bucket,
+You can use blocks-gcs-proxy with [Cloud Pub/Sub Notifications for Google Cloud Storage](https://cloud.google.com/storage/docs/pubsub-notifications).
+
+[Cloud Pub/Sub Notifications for Google Cloud Storage](https://cloud.google.com/storage/docs/pubsub-notifications) publishes
+a message to the specified topic after file is uploaded to the specified bucket. blocks-gcs-proxy accepts the messages and
+run your command.
+
+## How to setup
+
+1. Create notification config to your bucket
+2. Deploy/Run your container
+
+### Create notification config to your bucket
+
+```
+gsutil notification create -t projects/[Your-Project]/topics/[Your-Pipeline-Job-Topic] -f json gs://[Your-Bucket]
+```
+
+If you need the notification whose `eventType` is `OBJECT_FINALIZE`, you can add `-e OBJECT_FINALIZE` option to the
+above command like this:
+
+```
+gsutil notification create -t projects/[Your-Project]/topics/[Your-Pipeline-Job-Topic] -f json gs://[Your-Bucket] -e OBJECT_FINALIZE
+```
+
+You can see other eventTypes at https://cloud.google.com/storage/docs/pubsub-notifications#events .
+Type `gsutil notification create --help` for more detail.
+
+
+### Deploy/Run your container
+
+After setup the notification, `blocks-gcs-proxy` works well.
+
+### Tips
+
+#### Get eventTypes from each message
+
+You can pass the `eventType` of the message to your command by using `%{attrs.eventType}`.
+
+For example, the following command shows you them.
+
+```
+$ blocks-gcs-proxy echo "%{attrs.eventType}" "%{attrs.bucketId}" "%{attrs.objectId}"
+
+You can see other attributes at https://cloud.google.com/storage/docs/pubsub-notifications#format .
+
+
+## Examples
+
+- [blocks-gcs-proxy example with Cloud Pub/Sub Notifications](../examples/pubsub_notifications/README.md)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -6,7 +6,6 @@
 $ cd path/to/workspace
 $ git clone https://github.com/groovenauts/blocks-gcs-proxy.git
 $ cd blocks-gcs-proxy
-$ bundle
 $ export PIPELINE=pipeline01
 $ gcloud deployment-manager deployments create $PIPELINE --config test/pubsub.jinja
 ```

--- a/examples/command_options/README.md
+++ b/examples/command_options/README.md
@@ -6,7 +6,6 @@
 $ cd path/to/workspace
 $ git clone https://github.com/groovenauts/blocks-gcs-proxy.git
 $ cd blocks-gcs-proxy
-$ bundle
 $ export PIPELINE=akm-pipeline01
 $ gcloud deployment-manager deployments create $PIPELINE --config test/pubsub.jinja
 ```

--- a/examples/pubsub_notifications/Dockerfile
+++ b/examples/pubsub_notifications/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.6.0-alpha1
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/pubsub_notifications/Dockerfile
+++ b/examples/pubsub_notifications/Dockerfile
@@ -1,0 +1,19 @@
+# [config] IMAGE_NAME: "groovenauts/concurrent_batch_pubsub_notifications_example"
+# [config]
+# [config] WORKING_DIR: "."
+# [config] VERSION_SCRIPT: 'grep VERSION ../../version.go | cut -f2 -d\"'
+# [config] GIT_TAG_PREFIX: 'examples/pubsub_notifications/'
+
+FROM buildpack-deps:jessie-curl
+
+ENV APP_HOME /usr/app/batch_type_example
+COPY . $APP_HOME
+WORKDIR $APP_HOME
+
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.0-alpha1
+RUN mkdir -p /usr/app && \
+    curl -L --output ${APP_HOME}/blocks-gcs-proxy \
+         https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \
+    chmod +x ${APP_HOME}/blocks-gcs-proxy
+
+CMD ["./blocks-gcs-proxy", "echo", "%{attrs.eventType}", "gs://%{attrs.bucketId}/%{attrs.objectId}", "%{download_files.0}", "%{downloads_dir}"]

--- a/examples/pubsub_notifications/README.md
+++ b/examples/pubsub_notifications/README.md
@@ -1,0 +1,47 @@
+# blocks-gcs-proxy example with Cloud Pub/Sub Notifications
+
+See [Use blocks-gcs-proxy with Cloud Pub/Sub Notifications](../../doc/pubsub_notification.md)
+for more detail about background.
+
+## How to run application locally
+
+```
+$ cd path/to/workspace
+$ git clone https://github.com/groovenauts/blocks-gcs-proxy.git
+$ cd blocks-gcs-proxy
+$ export PIPELINE=pipeline01
+$ gcloud deployment-manager deployments create $PIPELINE --config test/pubsub.jinja
+```
+
+### Terminal 1
+
+Download [pubsub-devsub](https://github.com/akm/pubsub-devsub/releases) and put it into the directory on PATH.
+
+```
+$ export PIPELINE=pipeline01
+$ export PROJECT=your-gcp-project
+$ pubsub-devsub --project $PROJECT --subscription "${PIPELINE}-progress-subscription"
+```
+
+### Terminal 2
+
+Download [blocks-gcs-proxy](https://github.com/groovenauts/blocks-gcs-proxy/releases) and put it into the directory on PATH.
+
+```
+$ cd path/to/workspace/blocks-gcs-proxy
+$ cd examples/pubsub_notifications
+$ export PIPELINE=pipeline01
+$ export PROJECT=your-gcp-project
+$ blocks-gcs-proxy echo %{attrs.eventType} gs://%{attrs.bucketId}/%{attrs.objectId} %{download_files.0} %{downloads_dir}
+```
+
+### Terminal 3 Setup notification and upload files
+
+```
+$ export PIPELINE=pipeline01
+$ export PROJECT=your-gcp-project
+$ export TOPIC="projects/${PROJECT}/topics/${PIPELINE}-job-topic"
+$ export BUCKET="your-bucket"
+$ gsutil notification create -t $TOPIC -f json gs://$BUCKET
+$ gsutil cp [path/to/localFile] $BUCKET/path/to/remoteFile
+```

--- a/examples/pubsub_notifications/README.md
+++ b/examples/pubsub_notifications/README.md
@@ -45,6 +45,3 @@ $ export BUCKET="your-bucket"
 $ gsutil notification create -t $TOPIC -f json -e OBJECT_FINALIZE gs://$BUCKET
 $ gsutil cp [path/to/localFile] $BUCKET/path/to/remoteFile
 ```
-
-gsutil notification create -t projects/scenic-doodad-617/topics/akm-pipeline01-job-topic                -f json gs://blocks-gcs-proxy-test -e OBJECT_FINALIZE
-gsutil notification create -t projects/scenic-doodad-617/topics/akm-test-gcs-pubsub-notifications-topic -f json gs://akm-test

--- a/examples/pubsub_notifications/README.md
+++ b/examples/pubsub_notifications/README.md
@@ -42,6 +42,9 @@ $ export PIPELINE=pipeline01
 $ export PROJECT=your-gcp-project
 $ export TOPIC="projects/${PROJECT}/topics/${PIPELINE}-job-topic"
 $ export BUCKET="your-bucket"
-$ gsutil notification create -t $TOPIC -f json gs://$BUCKET
+$ gsutil notification create -t $TOPIC -f json -e OBJECT_FINALIZE gs://$BUCKET
 $ gsutil cp [path/to/localFile] $BUCKET/path/to/remoteFile
 ```
+
+gsutil notification create -t projects/scenic-doodad-617/topics/akm-pipeline01-job-topic                -f json gs://blocks-gcs-proxy-test -e OBJECT_FINALIZE
+gsutil notification create -t projects/scenic-doodad-617/topics/akm-test-gcs-pubsub-notifications-topic -f json gs://akm-test

--- a/examples/pubsub_notifications/config.json
+++ b/examples/pubsub_notifications/config.json
@@ -1,0 +1,16 @@
+{
+  "command": {
+    "dryrun": {{ or .BLOCKS_BATCH_DRYRUN "false" }}
+  },
+  "progress": {
+    "topic": "projects/{{ .PROJECT }}/topics/{{ .PIPELINE }}-progress-topic"
+  },
+  "job": {
+    "subscription": "projects/{{ .PROJECT }}/subscriptions/{{ .PIPELINE }}-job-subscription",
+    "pull_interval": {{ or .BLOCKS_BATCH_PULL_INTERVAL 60 }},
+    "sustainer": {
+      "delay": {{ or .BLOCKS_BATCH_SUSTAINER_DELAY 600 }},
+      "interval": {{ or .BLOCKS_BATCH_SUSTAINER_INTERVAL 540 }}
+    }
+  }
+}

--- a/job_message.go
+++ b/job_message.go
@@ -62,6 +62,19 @@ func (m *JobMessage) MessageId() string {
 }
 
 func (m *JobMessage) DownloadFiles() interface{} {
+	// See Cloud Pub/Sub Notifications for Google Cloud Storage
+	// https://cloud.google.com/storage/docs/pubsub-notifications
+	eventType, ok1 := m.raw.Message.Attributes["eventType"]
+	bucketId, ok2 := m.raw.Message.Attributes["bucketId"]
+	objectId, ok3 := m.raw.Message.Attributes["objectId"]
+	if ok1 && ok2 && ok3 {
+		if eventType != "OBJECT_FINALIZE" {
+			return nil
+		}
+		url := "gs://" + bucketId + "/" + objectId
+		return url
+	}
+
 	str, ok := m.raw.Message.Attributes["download_files"]
 	if !ok {
 		return nil

--- a/job_message.go
+++ b/job_message.go
@@ -72,7 +72,7 @@ func (m *JobMessage) DownloadFiles() interface{} {
 			return nil
 		}
 		url := "gs://" + bucketId + "/" + objectId
-		return url
+		return []interface{}{url}
 	}
 
 	str, ok := m.raw.Message.Attributes["download_files"]

--- a/job_setup_with_pubsub_notification_test.go
+++ b/job_setup_with_pubsub_notification_test.go
@@ -10,23 +10,22 @@ import (
 	pubsub "google.golang.org/api/pubsub/v1"
 )
 
-
 const (
 	bucket = "bucket1"
-	path1 = "path/to/file1"
-	url1 = "gs://" + bucket + "/" + path1
+	path1  = "path/to/file1"
+	url1   = "gs://" + bucket + "/" + path1
 	local1 = downloads_dir + "/" + bucket + "/" + path1
 )
 
 var (
-	BaseNotificationAttrs = map[string]string {
-		"objectId" : "path/to/file1",
-		"payloadFormat": "JSON_API_V1",
-		"resource": "projects/_/buckets/bucket1/objects/path/to/file1#1495443037537696",
-		"bucketId": "bucket1",
-		"eventType": "OBJECT_FINALIZE",
+	BaseNotificationAttrs = map[string]string{
+		"objectId":           "path/to/file1",
+		"payloadFormat":      "JSON_API_V1",
+		"resource":           "projects/_/buckets/bucket1/objects/path/to/file1#1495443037537696",
+		"bucketId":           "bucket1",
+		"eventType":          "OBJECT_FINALIZE",
 		"notificationConfig": "projects/_/buckets/bucket1/notificationConfigs/3",
-		"objectGeneration": "1495443037537696",
+		"objectGeneration":   "1495443037537696",
 	}
 
 	BaseNotificationData = `{
@@ -59,9 +58,9 @@ func TestJobSetupWithPubSubNotification1(t *testing.T) {
 			raw: &pubsub.ReceivedMessage{
 				AckId: "test-ack1",
 				Message: &pubsub.PubsubMessage{
-					Data: BaseNotificationData,
+					Data:       BaseNotificationData,
 					Attributes: BaseNotificationAttrs,
-					MessageId: "test-message1",
+					MessageId:  "test-message1",
 				},
 			},
 		},

--- a/job_setup_with_pubsub_notification_test.go
+++ b/job_setup_with_pubsub_notification_test.go
@@ -78,8 +78,8 @@ func TestJobSetupWithPubSubNotification1(t *testing.T) {
 		url1: local1,
 	}, job.downloadFileMap)
 
-	assert.Equal(t, url1, job.remoteDownloadFiles)
-	assert.Equal(t, local1, job.localDownloadFiles)
+	assert.Equal(t, []interface{}{url1}, job.remoteDownloadFiles)
+	assert.Equal(t, []interface{}{local1}, job.localDownloadFiles)
 
 	err = job.build()
 	assert.NoError(t, err)

--- a/job_setup_with_pubsub_notification_test.go
+++ b/job_setup_with_pubsub_notification_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	// "encoding/base64"
+	// "encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pubsub "google.golang.org/api/pubsub/v1"
+)
+
+
+const (
+	bucket = "bucket1"
+	path1 = "path/to/file1"
+	url1 = "gs://" + bucket + "/" + path1
+	local1 = downloads_dir + "/" + bucket + "/" + path1
+)
+
+var (
+	BaseNotificationAttrs = map[string]string {
+		"objectId" : "path/to/file1",
+		"payloadFormat": "JSON_API_V1",
+		"resource": "projects/_/buckets/bucket1/objects/path/to/file1#1495443037537696",
+		"bucketId": "bucket1",
+		"eventType": "OBJECT_FINALIZE",
+		"notificationConfig": "projects/_/buckets/bucket1/notificationConfigs/3",
+		"objectGeneration": "1495443037537696",
+	}
+
+	BaseNotificationData = `{
+  "kind": "storage#object",
+  "id": "bucket1/path/to/file1/1495443037537696",
+  "selfLink": "https://www.googleapis.com/storage/v1/b/bucket1/o/files%2Fnode-v4.5.0-linux-x64.tar.xz",
+  "name": "path/to/file1",
+  "bucket": "bucket1",
+  "generation": "1495443037537696",
+  "metageneration": "1",
+  "contentType": "binary/octet-stream",
+  "timeCreated": "2017-05-22T08:50:37.518Z",
+  "updated": "2017-05-22T08:50:37.518Z",
+  "storageClass": "REGIONAL",
+  "timeStorageClassUpdated": "2017-05-22T08:50:37.518Z",
+  "size": "8320540",
+  "md5Hash": "bXiRq/+p9S1mnM6EcdDGKQ==",
+  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/bucket1/o/files%2Fnode-v4.5.0-linux-x64.tar.xz?generation=1495443037537696&alt=media",
+  "crc32c": "J8Knpg==",
+  "etag": "CKCLo7iPg9QCEAE="
+}`
+)
+
+func TestJobSetupWithPubSubNotification1(t *testing.T) {
+	job := &Job{
+		config: &CommandConfig{
+			Template: []string{"cmd1", "%{download_files}", "%{uploads_dir}"},
+		},
+		message: &JobMessage{
+			raw: &pubsub.ReceivedMessage{
+				AckId: "test-ack1",
+				Message: &pubsub.PubsubMessage{
+					Data: BaseNotificationData,
+					Attributes: BaseNotificationAttrs,
+					MessageId: "test-message1",
+				},
+			},
+		},
+		workspace:     workspace,
+		downloads_dir: downloads_dir,
+		uploads_dir:   uploads_dir,
+	}
+
+	job.remoteDownloadFiles = job.message.DownloadFiles()
+	err := job.setupDownloadFiles()
+	assert.NoError(t, err)
+
+	assert.Equal(t, map[string]string{
+		url1: local1,
+	}, job.downloadFileMap)
+
+	assert.Equal(t, url1, job.remoteDownloadFiles)
+	assert.Equal(t, local1, job.localDownloadFiles)
+
+	err = job.build()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "cmd1", job.cmd.Path)
+	assert.Equal(t, []string{"cmd1", local1, uploads_dir}, job.cmd.Args)
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.5.6"
+const VERSION = "0.6.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.0-alpha1"
+const VERSION = "0.6.0"


### PR DESCRIPTION
From #47 

This PR have `blocks-gcs-proxy` support [Cloud Pub/Sub Notifications for Google Cloud Storage](https://cloud.google.com/storage/docs/pubsub-notifications).
Add [an example](https://github.com/groovenauts/blocks-gcs-proxy/blob/features/cloud_pubsub_notification_support/examples/pubsub_notifications/README.md) to try this feature.

See the [document](https://github.com/groovenauts/blocks-gcs-proxy/blob/features/cloud_pubsub_notification_support/doc/pubsub_notification.md) for more detail.
