### PR TITLE
Update blocks-gcs-proxy versions in examples

### DIFF
--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.4.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.1
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/command_options/Dockerfile
+++ b/examples/command_options/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.4.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/command_options/Dockerfile
+++ b/examples/command_options/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.1
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/devpub/Dockerfile
+++ b/examples/devpub/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/app && \
          https://github.com/groovenauts/pubsub-devpub/releases/download/v${PUBSUB_DEVPUB_VERSION}/pubsub-devpub_linux_amd64 && \
     chmod +x ${APP_HOME}/pubsub-devpub
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.1
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/devpub/Dockerfile
+++ b/examples/devpub/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /usr/app && \
          https://github.com/groovenauts/pubsub-devpub/releases/download/v${PUBSUB_DEVPUB_VERSION}/pubsub-devpub_linux_amd64 && \
     chmod +x ${APP_HOME}/pubsub-devpub
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.5.2
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \

--- a/examples/pubsub_notifications/Dockerfile
+++ b/examples/pubsub_notifications/Dockerfile
@@ -10,7 +10,7 @@ ENV APP_HOME /usr/app/batch_type_example
 COPY . $APP_HOME
 WORKDIR $APP_HOME
 
-ENV BLOCKS_GCS_PROXY_VERSION 0.6.0
+ENV BLOCKS_GCS_PROXY_VERSION 0.6.1
 RUN mkdir -p /usr/app && \
     curl -L --output ${APP_HOME}/blocks-gcs-proxy \
          https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \


### PR DESCRIPTION
Update `BLOCKS_GCS_PROXY_VERSION` in Dockerfile in `examples/basic` and `examples/devpub`.
