### PR TITLE
Pass job message attributes to progress messages and add UUID

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9d940b97492ab84644b47000b006c4f408bf1baa0717590911cd2200abb6c6d8
-updated: 2017-04-25T20:13:49.943036478+09:00
+hash: 153035d07a06439b8ab4e5b2e8e3bb9980a6b3d062804a4260c9d5e094ac10b2
+updated: 2017-07-14T18:27:00.438286103+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -16,10 +16,12 @@ imports:
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/groovenauts/blocks-variable
   version: 833d2f1e70b82c8a0a1149827906ab32aed40276
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/Sirupsen/logrus
-  version: 547e984ad93a90192134fc0fdb57a468edb514fe
+  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
 - name: github.com/urfave/cli
-  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
+  version: 4b90d79a682b4bf685762c7452db20f2a676ecb2
 - name: golang.org/x/net
   version: 69d4b8aa71caaaa75c3dfc11211d1be495abec7c
   subpackages:
@@ -39,7 +41,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: google.golang.org/api
@@ -87,6 +89,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,6 +13,8 @@ import:
   - iterator
 - package: github.com/Sirupsen/logrus
 - package: github.com/cenkalti/backoff
+- package: github.com/satori/go.uuid
+  version: ~1.1.0
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/job.go
+++ b/job.go
@@ -61,6 +61,9 @@ type Job struct {
 
 func (job *Job) run() error {
 	err := job.runWithoutErrorHandling()
+	if err == nil {
+		return nil
+	}
 	var f func() error
 	if job.retryable(err) {
 		f = job.withNotify(NACKSENDING, job.message.Nack)

--- a/job.go
+++ b/job.go
@@ -114,7 +114,7 @@ func (job *Job) runWithoutErrorHandling() error {
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func (job *Job) withNotify(step JobStep, f func() error) func() error {

--- a/job.go
+++ b/job.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/groovenauts/blocks-variable"
+	"github.com/satori/go.uuid"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -51,6 +52,9 @@ type Job struct {
 	downloadFileMap     map[string]string
 	remoteDownloadFiles interface{}
 	localDownloadFiles  interface{}
+
+	// This is set at setupExecUUID
+	execUUID string
 
 	cmd *exec.Cmd
 }
@@ -122,6 +126,8 @@ func (job *Job) prepare() error {
 		return err
 	}
 
+	job.message.InsertExecUUID()
+
 	err = job.setupWorkspace()
 	if err != nil {
 		return err
@@ -147,6 +153,11 @@ func (job *Job) prepare() error {
 		return err
 	}
 	return nil
+}
+
+func (job *Job) setupExecUUID() {
+	job.execUUID = uuid.NewV4().String()
+	job.message.raw.Message.Attributes[ExecUUIDKey] = job.execUUID
 }
 
 func (job *Job) setupWorkspace() error {

--- a/job.go
+++ b/job.go
@@ -109,7 +109,7 @@ func (job *Job) runWithoutErrorHandling() error {
 }
 
 func (job *Job) withNotify(step JobStep, f func() error) func() error {
-	return job.notification.wrap(job.message.MessageId(), step, f)
+	return job.notification.wrap(job.message.MessageId(), step, job.message.raw.Message.Attributes, f)
 }
 
 func (job *Job) prepare() error {

--- a/job_message.go
+++ b/job_message.go
@@ -216,7 +216,7 @@ func (m *JobMessage) waitAndSendMAD(notification *ProgressNotification, nextLimi
 		log.WithFields(logAttrs).Errorln("waitAndSendMAD ModifyAckDeadline")
 		msg := fmt.Sprintf("Failed modifyAckDeadline %v, %v, %v cause of %v\n", m.sub, m.raw.AckId, m.config.Delay, err)
 		log.WithFields(logAttrs).Fatalf(msg)
-		notification.notifyProgress(m.MessageId(), WORKING, false, log.ErrorLevel, msg)
+		notification.notifyProgress(m.MessageId(), WORKING, false, log.ErrorLevel, m.raw.Message.Attributes, msg)
 	}
 	return nil
 }

--- a/job_message.go
+++ b/job_message.go
@@ -50,6 +50,8 @@ type (
 	}
 )
 
+const ExecUUIDKey = "concurrent-batch.exec-uuid"
+
 func (m *JobMessage) Validate() error {
 	if m.MessageId() == "" {
 		return &InvalidJobError{msg: "no MessageId is given"}
@@ -59,6 +61,9 @@ func (m *JobMessage) Validate() error {
 
 func (m *JobMessage) MessageId() string {
 	return m.raw.Message.MessageId
+}
+
+func (m *JobMessage) InsertExecUUID() {
 }
 
 func (m *JobMessage) DownloadFiles() interface{} {

--- a/job_test.go
+++ b/job_test.go
@@ -39,6 +39,15 @@ func NewBasicJob() *Job {
 	}
 }
 
+func TestJobSetupExecUUIDNormal(t *testing.T) {
+	job := NewBasicJob()
+	assert.Empty(t, job.execUUID)
+	assert.Empty(t, job.message.raw.Message.Attributes[ExecUUIDKey])
+	job.setupExecUUID()
+	assert.NotEmpty(t, job.execUUID)
+	assert.Equal(t, job.execUUID, job.message.raw.Message.Attributes[ExecUUIDKey])
+}
+
 func TestJobBuildNormal(t *testing.T) {
 	job := NewBasicJob()
 	err := job.build()

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -76,16 +76,15 @@ func (pn *ProgressNotification) notifyProgressWithOpts(job_msg_id string, progre
 	if pn.logLevel < level {
 		return nil
 	}
-	attrs := map[string]string{
-		"progress":       strconv.Itoa(int(progress)),
-		"completed":      strconv.FormatBool(completed),
-		"job_message_id": job_msg_id,
-		"level":          level.String(),
-		"host":           pn.config.Hostname,
-	}
+	attrs := map[string]string{}
 	for k, v := range opts {
 		attrs[k] = v
 	}
+	attrs["progress"] = strconv.Itoa(int(progress))
+	attrs["completed"] = strconv.FormatBool(completed)
+	attrs["job_message_id"] = job_msg_id
+	attrs["level"] = level.String()
+	attrs["host"] = pn.config.Hostname
 	logAttrs := log.Fields{}
 	for k, v := range attrs {
 		logAttrs[k] = v

--- a/progress_notification_test.go
+++ b/progress_notification_test.go
@@ -58,21 +58,25 @@ func TestProgressNotificationNotify(t *testing.T) {
 		logLevel:  log.InfoLevel,
 	}
 
+	baseAttrs := map[string]string{
+		"msg_id": "1234",
+	}
+
 	// Normal Pattern
 	publisher.Invocations = []*PublishInvocation{}
 
-	notification.notify(DummyJobID, INITIALIZING, STARTING)
-	notification.notify(DummyJobID, INITIALIZING, SUCCESS)
-	notification.notify(DummyJobID, DOWNLOADING, STARTING)
-	notification.notify(DummyJobID, DOWNLOADING, SUCCESS)
-	notification.notify(DummyJobID, EXECUTING, STARTING)
-	notification.notify(DummyJobID, EXECUTING, SUCCESS)
-	notification.notify(DummyJobID, UPLOADING, STARTING)
-	notification.notify(DummyJobID, UPLOADING, SUCCESS)
-	notification.notify(DummyJobID, CLEANUP, STARTING)
-	notification.notify(DummyJobID, CLEANUP, SUCCESS)
-	notification.notify(DummyJobID, ACKSENDING, STARTING)
-	notification.notify(DummyJobID, ACKSENDING, SUCCESS)
+	notification.notify(DummyJobID, INITIALIZING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, INITIALIZING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, DOWNLOADING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, DOWNLOADING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, EXECUTING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, EXECUTING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, UPLOADING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, UPLOADING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, CLEANUP, STARTING, baseAttrs)
+	notification.notify(DummyJobID, CLEANUP, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, ACKSENDING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, ACKSENDING, SUCCESS, baseAttrs)
 
 	assert.Equal(t, len(publisher.Invocations), 2)
 
@@ -106,22 +110,25 @@ func TestProgressNotificationNotify(t *testing.T) {
 		assert.Equal(t, expected.progress, attrs["progress"])
 		assert.Equal(t, expected.completed, attrs["completed"])
 		assert.Equal(t, expected.level, attrs["level"])
+		for k, v := range baseAttrs {
+			assert.Equal(t, v, attrs[k])
+		}
 	}
 
 	// Executing failure pattern
 
 	publisher.Invocations = []*PublishInvocation{}
 
-	notification.notify(DummyJobID, INITIALIZING, STARTING)
-	notification.notify(DummyJobID, INITIALIZING, SUCCESS)
-	notification.notify(DummyJobID, DOWNLOADING, STARTING)
-	notification.notify(DummyJobID, DOWNLOADING, SUCCESS)
-	notification.notify(DummyJobID, EXECUTING, STARTING)
-	notification.notify(DummyJobID, EXECUTING, FAILURE)
-	notification.notify(DummyJobID, CLEANUP, STARTING)
-	notification.notify(DummyJobID, CLEANUP, SUCCESS)
-	notification.notify(DummyJobID, NACKSENDING, STARTING)
-	notification.notify(DummyJobID, NACKSENDING, SUCCESS)
+	notification.notify(DummyJobID, INITIALIZING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, INITIALIZING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, DOWNLOADING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, DOWNLOADING, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, EXECUTING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, EXECUTING, FAILURE, baseAttrs)
+	notification.notify(DummyJobID, CLEANUP, STARTING, baseAttrs)
+	notification.notify(DummyJobID, CLEANUP, SUCCESS, baseAttrs)
+	notification.notify(DummyJobID, NACKSENDING, STARTING, baseAttrs)
+	notification.notify(DummyJobID, NACKSENDING, SUCCESS, baseAttrs)
 
 	assert.Equal(t, len(publisher.Invocations), 3)
 
@@ -164,5 +171,8 @@ func TestProgressNotificationNotify(t *testing.T) {
 		assert.Equal(t, expected.progress, attrs["progress"])
 		assert.Equal(t, expected.completed, attrs["completed"])
 		assert.Equal(t, expected.level, attrs["level"])
+		for k, v := range baseAttrs {
+			assert.Equal(t, v, attrs[k])
+		}
 	}
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3-alpha2"
+const VERSION = "0.6.3-alpha3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3-alpha4"
+const VERSION = "0.6.3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3-alpha1"
+const VERSION = "0.6.3-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3-alpha3"
+const VERSION = "0.6.3-alpha4"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.2"
+const VERSION = "0.6.3-alpha1"


### PR DESCRIPTION
This PR is for #51 

- Pass job message attributes to progress messages
  - Let subscriber get the attribute which the client gave to job message
  - `concurrent_batch.pipeline_job_id` will pass to progress message
    - It's added by https://github.com/groovenauts/blocks-concurrent-batch-agent/pull/40
- Set UUID to progress messages as `concurrent-batch.exec-uuid`
  - Let subscriber distinguish job executions
- Retry if command fails