### PR TITLE
Truncate attribute value over 1024 bytes

### DIFF
--- a/progress_notification.go
+++ b/progress_notification.go
@@ -76,7 +76,12 @@ func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progr
 	}
 	attrs := map[string]string{}
 	for k, v := range opts {
-		attrs[k] = v
+		buf := []byte(v)
+		if len(buf) > 1024 {
+			attrs[k] = string(buf[0:1024])
+		} else {
+			attrs[k] = v
+		}
 	}
 	attrs["progress"] = strconv.Itoa(int(progress))
 	attrs["completed"] = strconv.FormatBool(completed)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.3"
+const VERSION = "0.6.4-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.4-alpha1"
+const VERSION = "0.6.4"


### PR DESCRIPTION
`blocks-gcs-proxy` can treat attribute value over 1024 bytes by #33 and passes job message attributes to progress messages.
If long attribute value with `use-data-as-attributes` flag, `blocks-gcs-proxy` got the following error when it publishes progress messages.

```
Error 400: One of the attributes in the request has a value that is too long. The length is xxxxx characters, but the maximum allowed is 1024. Refer to https://cloud.google.com/pubsub/quotas for more information.
```

So `blocks-gcs-proxy` truncates the attribute value over 1024 bytes but doesn't truncate important values by this PR.
