### PR TITLE
Max tries of download and upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ specified by `job.subscription` in `config.json`.
 | log.level | string | False | `info` | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
 | command   | map | False |  |  |
 | command.dryrun | bool | False | `false` | Don't run the command if this is true. |
-| command.downloaders | int | False | 1 | The number of thread to download. |
-| command.uploaders | int | False | 1 | The number of thread to upload. |
 | command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
+| download           | map | False |  |  |
+| download.workers   | int | False | 1 | The number of thread to download. |
+| download.max_tries | int | False | 0 | The number of tries to download. |
+| upload           | map | False |  |  |
+| upload.workers   | int | False | 1 | The number of thread to upload. |
+| upload.max_tries | int | False | 0 | The number of tries to upload. |
 
 
 ### Multiple command options

--- a/cli.go
+++ b/cli.go
@@ -45,7 +45,7 @@ func newApp() *cli.App {
 				config := &ProcessConfig{}
 				config.Log = &LogConfig{Level: "debug"}
 				config.setup([]string{})
-				config.Command.Downloaders = c.Int("downloaders")
+				config.Download.Workers = c.Int("downloaders")
 				config.Job.Sustainer = &JobSustainerConfig{
 					Disabled: true,
 				}
@@ -88,7 +88,7 @@ func newApp() *cli.App {
 				config := &ProcessConfig{}
 				config.Log = &LogConfig{Level: "debug"}
 				config.setup([]string{})
-				config.Command.Uploaders = c.Int("uploaders")
+				config.Upload.Workers = c.Int("uploaders")
 				config.Job.Sustainer = &JobSustainerConfig{
 					Disabled: true,
 				}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 153035d07a06439b8ab4e5b2e8e3bb9980a6b3d062804a4260c9d5e094ac10b2
-updated: 2017-07-14T18:27:00.438286103+09:00
+hash: 4700d53109e387685ad644c032f07400bb2356439a0ed088aa8fccb960618a57
+updated: 2017-08-16T14:52:24.202421095+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -7,7 +7,8 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/cenkalti/backoff
-  version: b02f2bbce11d7ea6b97f282ef1771b0fe2f65ef3
+  version: 61153c768f31ee5f130071d08fc82b85208528de
+  repo: https://github.com/cenkalti/backoff.git
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,9 +12,10 @@ import:
   - pubsub/v1
   - iterator
 - package: github.com/Sirupsen/logrus
-- package: github.com/cenkalti/backoff
 - package: github.com/satori/go.uuid
   version: ~1.1.0
+- package: github.com/cenkalti/backoff
+  repo: https://github.com/cenkalti/backoff.git
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/job.go
+++ b/job.go
@@ -23,8 +23,6 @@ type CommandConfig struct {
 	Template    []string            `json:"-"`
 	Options     map[string][]string `json:"options,omitempty"`
 	Dryrun      bool                `json:"dryrun,omitempty"`
-	Uploaders   int                 `json:"uploaders,omitempty"`
-	Downloaders int                 `json:"downloaders,omitempty"`
 }
 
 func (c *CommandConfig) setup() {

--- a/job.go
+++ b/job.go
@@ -36,6 +36,10 @@ func (c *CommandConfig) setup() {
 
 type Job struct {
 	config *CommandConfig
+
+	downloadConfig *WorkerConfig
+	uploadConfig   *WorkerConfig
+
 	// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
 	message      *JobMessage
 	notification *ProgressNotification
@@ -420,10 +424,11 @@ func (job *Job) downloadFiles() error {
 	}
 
 	downloaders := TargetWorkers{}
-	for i := 0; i < job.config.Downloaders; i++ {
+	for i := 0; i < job.downloadConfig.Workers; i++ {
 		downloader := &TargetWorker{
 			name: "downoad",
 			impl: job.storage.Download,
+			maxTries: job.downloadConfig.MaxTries,
 		}
 		downloaders = append(downloaders, downloader)
 	}
@@ -472,10 +477,11 @@ func (job *Job) uploadFiles() error {
 	}
 
 	uploaders := TargetWorkers{}
-	for i := 0; i < job.config.Uploaders; i++ {
+	for i := 0; i < job.uploadConfig.Workers; i++ {
 		uploader := &TargetWorker{
 			name: "upload",
 			impl: job.storage.Upload,
+			maxTries: job.uploadConfig.MaxTries,
 		}
 		uploaders = append(uploaders, uploader)
 	}

--- a/job.go
+++ b/job.go
@@ -20,9 +20,9 @@ import (
 )
 
 type CommandConfig struct {
-	Template    []string            `json:"-"`
-	Options     map[string][]string `json:"options,omitempty"`
-	Dryrun      bool                `json:"dryrun,omitempty"`
+	Template []string            `json:"-"`
+	Options  map[string][]string `json:"options,omitempty"`
+	Dryrun   bool                `json:"dryrun,omitempty"`
 }
 
 type Job struct {
@@ -417,8 +417,8 @@ func (job *Job) downloadFiles() error {
 	downloaders := TargetWorkers{}
 	for i := 0; i < job.downloadConfig.Workers; i++ {
 		downloader := &TargetWorker{
-			name: "downoad",
-			impl: job.storage.Download,
+			name:     "downoad",
+			impl:     job.storage.Download,
 			maxTries: job.downloadConfig.MaxTries,
 		}
 		downloaders = append(downloaders, downloader)
@@ -470,8 +470,8 @@ func (job *Job) uploadFiles() error {
 	uploaders := TargetWorkers{}
 	for i := 0; i < job.uploadConfig.Workers; i++ {
 		uploader := &TargetWorker{
-			name: "upload",
-			impl: job.storage.Upload,
+			name:     "upload",
+			impl:     job.storage.Upload,
 			maxTries: job.uploadConfig.MaxTries,
 		}
 		uploaders = append(uploaders, uploader)

--- a/job.go
+++ b/job.go
@@ -25,15 +25,6 @@ type CommandConfig struct {
 	Dryrun      bool                `json:"dryrun,omitempty"`
 }
 
-func (c *CommandConfig) setup() {
-	if c.Downloaders < 1 {
-		c.Downloaders = 1
-	}
-	if c.Uploaders < 1 {
-		c.Uploaders = 1
-	}
-}
-
 type Job struct {
 	config *CommandConfig
 

--- a/process.go
+++ b/process.go
@@ -23,6 +23,8 @@ type (
 		Job      *JobSubscriptionConfig      `json:"job,omitempty"`
 		Progress *ProgressNotificationConfig `json:"progress,omitempty"`
 		Log      *LogConfig                  `json:"log,omitempty"`
+		Download *WorkerConfig               `json:"download"`
+		Upload   *WorkerConfig               `json:"upload"`
 	}
 )
 

--- a/process.go
+++ b/process.go
@@ -50,6 +50,16 @@ func (c *ProcessConfig) setup(args []string) error {
 	if err != nil {
 		return err
 	}
+
+	if c.Download == nil {
+		c.Download = &WorkerConfig{}
+	}
+	c.Download.setup()
+
+	if c.Upload == nil {
+		c.Upload = &WorkerConfig{}
+	}
+	c.Upload.setup()
 	return nil
 }
 
@@ -165,6 +175,8 @@ func (p *Process) run() error {
 	err := p.subscription.listen(func(msg *JobMessage) error {
 		job := &Job{
 			config:       p.config.Command,
+			downloadConfig: p.config.Download,
+			uploadConfig: p.config.Upload,
 			message:      msg,
 			notification: p.notification,
 			storage:      p.storage,

--- a/process.go
+++ b/process.go
@@ -32,7 +32,6 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
-	c.Command.setup()
 
 	c.Command.Template = args
 	if c.Job == nil {

--- a/process.go
+++ b/process.go
@@ -173,12 +173,12 @@ func (p *Process) run() error {
 	log.WithFields(logAttrs).Infoln("Start listening")
 	err := p.subscription.listen(func(msg *JobMessage) error {
 		job := &Job{
-			config:       p.config.Command,
+			config:         p.config.Command,
 			downloadConfig: p.config.Download,
-			uploadConfig: p.config.Upload,
-			message:      msg,
-			notification: p.notification,
-			storage:      p.storage,
+			uploadConfig:   p.config.Upload,
+			message:        msg,
+			notification:   p.notification,
+			storage:        p.storage,
 		}
 		err := job.run()
 		if err != nil {

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -117,7 +117,7 @@ func TestLoadProcessConfigWithDefaultValues(t *testing.T) {
 			assert.Equal(t, float64(600), config.Job.Sustainer.Delay)
 			assert.Equal(t, float64(540), config.Job.Sustainer.Interval)
 			assert.Equal(t, fmt.Sprintf("projects/%v/topics/%v-progress-topic", proj, pipeline), config.Progress.Topic)
-			assert.Equal(t, int(8), config.Command.Uploaders)
+			assert.Equal(t, int(8), config.Upload.Workers)
 		}
 	})
 }

--- a/target_worker.go
+++ b/target_worker.go
@@ -32,6 +32,7 @@ type TargetWorker struct {
 	impl    func(bucket, object, srcPath string) error
 	done    bool
 	error   error
+	maxTries int
 }
 
 func (w *TargetWorker) run() {
@@ -59,7 +60,8 @@ func (w *TargetWorker) run() {
 
 		eb := backoff.NewExponentialBackOff()
 		eb.InitialInterval = 30 * time.Second
-		err := backoff.Retry(f, eb)
+		b := backoff.WithMaxTries(eb, uint64(w.maxTries))
+		err := backoff.Retry(f, b)
 		flds["error"] = err
 		if err != nil {
 			log.WithFields(flds).Errorf("Failed to %v\n", w.name)

--- a/target_worker.go
+++ b/target_worker.go
@@ -14,7 +14,7 @@ type WorkerConfig struct {
 	MaxTries int `json:"max_tries,omitempty"`
 }
 
-func (c *WorkerConfig) setup(){
+func (c *WorkerConfig) setup() {
 	if c.Workers < 1 {
 		c.Workers = 1
 	}
@@ -27,11 +27,11 @@ type Target struct {
 }
 
 type TargetWorker struct {
-	name    string
-	targets chan *Target
-	impl    func(bucket, object, srcPath string) error
-	done    bool
-	error   error
+	name     string
+	targets  chan *Target
+	impl     func(bucket, object, srcPath string) error
+	done     bool
+	error    error
 	maxTries int
 }
 

--- a/target_worker.go
+++ b/target_worker.go
@@ -9,6 +9,17 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
+type WorkerConfig struct {
+	Workers  int `json:"workers,omitempty"`
+	MaxTries int `json:"max_tries,omitempty"`
+}
+
+func (c *WorkerConfig) setup(){
+	if c.Workers < 1 {
+		c.Workers = 1
+	}
+}
+
 type Target struct {
 	Bucket    string
 	Object    string

--- a/test/config_with_env_and_default3.json
+++ b/test/config_with_env_and_default3.json
@@ -3,8 +3,7 @@
     "options": {
       "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
-    },
-    "uploaders": {{ or .UPLOADERS 8}}
+    }
   },
   "job": {
     "subscription": "projects/{{ .GCP_PROJECT }}/subscriptions/{{ or .PIPELINE "pipeline01" }}-job-subscription",
@@ -16,5 +15,8 @@
   },
   "progress": {
     "topic": "projects/{{ .GCP_PROJECT }}/topics/{{ or .PIPELINE "pipeline01" }}-progress-topic"
+  },
+  "upload": {
+    "workers": {{ or .UPLOADERS 8}}
   }
 }

--- a/test/full.json
+++ b/test/full.json
@@ -4,9 +4,7 @@
       "key1": ["./cmd1", "%{uploads_dir}", "%{download_files.foo}", "%{download_files.bar}"],
       "key2": ["./cmd2", "%{uploads_dir}", "%{download_files}"]
     },
-    "dryrun": true,
-    "downloaders": 5,
-    "uploaders": 8
+    "dryrun": true
   },
   "job": {
     "subscription": "projects/dummy-gcp-proj/subscriptions/test-job-subscription",
@@ -22,5 +20,13 @@
   },
   "log": {
     "level": "debug"
+  },
+  "download": {
+    "workers": 5,
+    "max_tries": 6
+  },
+  "upload": {
+    "workers": 8,
+    "max_tries": 9
   }
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6.4"
+const VERSION = "0.7.0-alpha1"


### PR DESCRIPTION
This PR is for #50 

- Add `download.max_tries` and `upload.max_tries` to config.json
- Remove `ommand.downloaders` and `command.uploaders` and add `download.workers` and `upload.workers`
- Update the version of `github.com/cenkalti/backoff` to use `WithMaxTries` function

## Attention

You have to modify your `config.json` to use this version or later.
