### PR TITLE
Error name with nested configurations

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -97,3 +99,28 @@ func (e *CompositeError) Any(f func(error) bool) bool {
 	}
 	return false
 }
+
+type ConfigError struct {
+	Name      string
+	Ancestors []string
+	Message   string
+}
+
+func (e *ConfigError) Setup() {
+	if e.Ancestors == nil {
+		e.Ancestors = []string{e.Name}
+	}
+}
+
+func (e *ConfigError) Add(ancestor string) {
+	e.Setup()
+	e.Ancestors = append(e.Ancestors, ancestor)
+}
+
+func (e *ConfigError) Error() string {
+	e.Setup()
+	sort.Sort(sort.Reverse(sort.StringSlice(e.Ancestors)))
+	return fmt.Sprintf("%s %s", strings.Join(e.Ancestors, "."), e.Message)
+}
+
+type ConfigSetup func()*ConfigError

--- a/errors.go
+++ b/errors.go
@@ -123,4 +123,4 @@ func (e *ConfigError) Error() string {
 	return fmt.Sprintf("%s %s", strings.Join(e.Ancestors, "."), e.Message)
 }
 
-type ConfigSetup func()*ConfigError
+type ConfigSetup func() *ConfigError

--- a/job.go
+++ b/job.go
@@ -25,6 +25,10 @@ type CommandConfig struct {
 	Dryrun   bool                `json:"dryrun,omitempty"`
 }
 
+func (c *CommandConfig) setup() *ConfigError {
+	return nil
+}
+
 type Job struct {
 	config *CommandConfig
 

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -14,10 +14,11 @@ type JobSubscriptionConfig struct {
 	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
 }
 
-func (c *JobSubscriptionConfig) setup() {
+func (c *JobSubscriptionConfig) setup() *ConfigError {
 	if c.PullInterval == 0 {
 		c.PullInterval = 10
 	}
+	return nil
 }
 
 func (c *JobSubscriptionConfig) setupSustainer(puller Puller) error {

--- a/log.go
+++ b/log.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -8,14 +9,27 @@ type LogConfig struct {
 	Level string `json:"level,omitempty"`
 }
 
-func (c *LogConfig) setup() error {
+func (c *LogConfig) setup() *ConfigError {
+	setups := []ConfigSetup{
+		c.setupLevel,
+	}
+	for _, setup := range setups {
+		err := setup()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *LogConfig) setupLevel() *ConfigError {
 	if c.Level == "" {
 		c.Level = "info"
 	}
 	level, err := log.ParseLevel(c.Level)
 	if err != nil {
-		log.Warnf("Invalid log level: %q\n", c.Level)
-		return err
+		log.Warnf("Error on log.ParseLevel level: %q because of %v\n", c.Level, err)
+		return &ConfigError{Name: "level", Message: fmt.Sprintf("is invalid because of %v", err)}
 	}
 	log.SetLevel(level)
 	return nil

--- a/process.go
+++ b/process.go
@@ -32,18 +32,28 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
+	err := c.Command.setup()
+	if err != nil {
+		err.Add("command")
+		return err
+	}
 
 	c.Command.Template = args
 	if c.Job == nil {
 		c.Job = &JobSubscriptionConfig{}
 	}
-	c.Job.setup()
+	err = c.Job.setup()
+	if err != nil {
+		err.Add("job")
+		return err
+	}
 
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
-	err := c.Progress.setup()
+	err = c.Progress.setup()
 	if err != nil {
+		err.Add("progress")
 		return err
 	}
 
@@ -52,18 +62,28 @@ func (c *ProcessConfig) setup(args []string) error {
 	}
 	err = c.Log.setup()
 	if err != nil {
+		err.Add("log")
 		return err
 	}
 
 	if c.Download == nil {
 		c.Download = &WorkerConfig{}
 	}
-	c.Download.setup()
+	err = c.Download.setup()
+	if err != nil {
+		err.Add("download")
+		return err
+	}
 
 	if c.Upload == nil {
 		c.Upload = &WorkerConfig{}
 	}
-	c.Upload.setup()
+	err = c.Upload.setup()
+	if err != nil {
+		err.Add("upload")
+		return err
+	}
+
 	return nil
 }
 

--- a/process.go
+++ b/process.go
@@ -29,62 +29,67 @@ type (
 )
 
 func (c *ProcessConfig) setup(args []string) error {
+	setups := map[string]ConfigSetup{
+		"command": func()*ConfigError{
+			return c.setupCommand(args)
+		},
+		"job": c.setupJob,
+		"progress": c.setupProgress,
+		"log": c.setupLog,
+		"download": c.setupDownload,
+		"upload": c.setupUpload,
+	}
+	for key, setup := range setups {
+		err := setup()
+		if err != nil {
+			err.Add(key)
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ProcessConfig) setupCommand(args []string) *ConfigError {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
-	err := c.Command.setup()
-	if err != nil {
-		err.Add("command")
-		return err
-	}
-
 	c.Command.Template = args
+	return c.Command.setup()
+}
+
+func (c *ProcessConfig) setupJob() *ConfigError {
 	if c.Job == nil {
 		c.Job = &JobSubscriptionConfig{}
 	}
-	err = c.Job.setup()
-	if err != nil {
-		err.Add("job")
-		return err
-	}
+	return c.Job.setup()
+}
 
+func (c *ProcessConfig) setupProgress() *ConfigError {
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
-	err = c.Progress.setup()
-	if err != nil {
-		err.Add("progress")
-		return err
-	}
+	return c.Progress.setup()
+}
 
+func (c *ProcessConfig) setupLog() *ConfigError {
 	if c.Log == nil {
 		c.Log = &LogConfig{}
 	}
-	err = c.Log.setup()
-	if err != nil {
-		err.Add("log")
-		return err
-	}
+	return c.Log.setup()
+}
 
+func (c *ProcessConfig) setupDownload() *ConfigError {
 	if c.Download == nil {
 		c.Download = &WorkerConfig{}
 	}
-	err = c.Download.setup()
-	if err != nil {
-		err.Add("download")
-		return err
-	}
+	return c.Download.setup()
+}
 
+func (c *ProcessConfig) setupUpload() *ConfigError {
 	if c.Upload == nil {
 		c.Upload = &WorkerConfig{}
 	}
-	err = c.Upload.setup()
-	if err != nil {
-		err.Add("upload")
-		return err
-	}
-
-	return nil
+	return c.Upload.setup()
 }
 
 func LoadProcessConfig(path string) (*ProcessConfig, error) {

--- a/process.go
+++ b/process.go
@@ -42,10 +42,15 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
+	err := c.Progress.setup()
+	if err != nil {
+		return err
+	}
+
 	if c.Log == nil {
 		c.Log = &LogConfig{}
 	}
-	err := c.Log.setup()
+	err = c.Log.setup()
 	if err != nil {
 		return err
 	}

--- a/process.go
+++ b/process.go
@@ -30,14 +30,14 @@ type (
 
 func (c *ProcessConfig) setup(args []string) error {
 	setups := map[string]ConfigSetup{
-		"command": func()*ConfigError{
+		"command": func() *ConfigError {
 			return c.setupCommand(args)
 		},
-		"job": c.setupJob,
+		"job":      c.setupJob,
 		"progress": c.setupProgress,
-		"log": c.setupLog,
+		"log":      c.setupLog,
 		"download": c.setupDownload,
-		"upload": c.setupUpload,
+		"upload":   c.setupUpload,
 	}
 	for key, setup := range setups {
 		err := setup()

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -19,7 +19,7 @@ type ProgressNotificationConfig struct {
 	Hostname string `json:"hostname"`
 }
 
-func (c *ProgressNotificationConfig) setup() {
+func (c *ProgressNotificationConfig) setup() *ConfigError {
 	if c.LogLevel == "" {
 		c.LogLevel = log.InfoLevel.String()
 	}
@@ -27,11 +27,12 @@ func (c *ProgressNotificationConfig) setup() {
 	if c.Hostname == "" {
 		h, err := os.Hostname()
 		if err != nil {
-			c.Hostname = "Unknown"
+			return &ConfigError{Name: "hostname", Message: "failed to get from OS"}
 		} else {
 			c.Hostname = h
 		}
 	}
+	return nil
 }
 
 type ProgressNotification struct {

--- a/target_worker.go
+++ b/target_worker.go
@@ -14,10 +14,11 @@ type WorkerConfig struct {
 	MaxTries int `json:"max_tries,omitempty"`
 }
 
-func (c *WorkerConfig) setup() {
+func (c *WorkerConfig) setup() *ConfigError {
 	if c.Workers < 1 {
 		c.Workers = 1
 	}
+	return nil
 }
 
 type Target struct {


### PR DESCRIPTION
The configuration has tree structure and sub configurations doesn't know its super configuration.
If a sub configuration returned an error, the error didn't include the super configuration information. 
For example, an error message about `log.level` didn't include `log` because `LogConfig` doesn't know that the super configuration calls `LogConfig` as `log`.
So this PR allow to add the name which super configuration calls sub configuration to the error from sub configuration.

