### PR TITLE
Stackdriver logging and error reporting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ specified by `job.subscription` in `config.json`.
 | log       | map    | False |  |  |
 | log.level | string | False | `info` | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
 | log.stackdriver | map | False |  |  |
+| log.stackdriver.project_id | string        | True |  | GCP Project ID |
+| log.stackdriver.log_name   | string        | True |  | The resource name of the log that will receive the log entries |
 | log.stackdriver.type   | string            | True |  | The type of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
 | log.stackdriver.labels | map[string]string | True |  | The labels of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
 | command   | map | False |  |  |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ specified by `job.subscription` in `config.json`.
 | log.stackdriver.log_name   | string        | True |  | The resource name of the log that will receive the log entries |
 | log.stackdriver.type   | string            | True |  | The type of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
 | log.stackdriver.labels | map[string]string | True |  | The labels of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
+| log.stackdriver.error_reporting_service | string | False |  | The service name of [ServiceContext](https://cloud.google.com/error-reporting/reference/rest/v1beta1/ServiceContext) |
 | command   | map | False |  |  |
 | command.dryrun | bool | False | `false` | Don't run the command if this is true. |
 | command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ specified by `job.subscription` in `config.json`.
 | progress.hostname | string | False | (hostname) | Hostname attribute value of job progress message |
 | log       | map    | False |  |  |
 | log.level | string | False | `info` | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
+| log.stackdriver | map | False |  |  |
+| log.stackdriver.type   | string            | True |  | The type of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
+| log.stackdriver.labels | map[string]string | True |  | The labels of [Monitored resource](https://cloud.google.com/logging/docs/api/v2/resource-list) |
 | command   | map | False |  |  |
 | command.dryrun | bool | False | `false` | Don't run the command if this is true. |
 | command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -97,3 +99,28 @@ func (e *CompositeError) Any(f func(error) bool) bool {
 	}
 	return false
 }
+
+type ConfigError struct {
+	Name      string
+	Ancestors []string
+	Message   string
+}
+
+func (e *ConfigError) Setup() {
+	if e.Ancestors == nil {
+		e.Ancestors = []string{e.Name}
+	}
+}
+
+func (e *ConfigError) Add(ancestor string) {
+	e.Setup()
+	e.Ancestors = append(e.Ancestors, ancestor)
+}
+
+func (e *ConfigError) Error() string {
+	e.Setup()
+	sort.Sort(sort.Reverse(sort.StringSlice(e.Ancestors)))
+	return fmt.Sprintf("%s %s", strings.Join(e.Ancestors, "."), e.Message)
+}
+
+type ConfigSetup func()*ConfigError

--- a/errors.go
+++ b/errors.go
@@ -123,4 +123,4 @@ func (e *ConfigError) Error() string {
 	return fmt.Sprintf("%s %s", strings.Join(e.Ancestors, "."), e.Message)
 }
 
-type ConfigSetup func()*ConfigError
+type ConfigSetup func() *ConfigError

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4700d53109e387685ad644c032f07400bb2356439a0ed088aa8fccb960618a57
-updated: 2017-08-16T14:52:24.202421095+09:00
+hash: 8adcc5132c3de8fd9deead6e757f35e3965988cae27a92790eefb309cb58e3e0
+updated: 2017-08-17T14:58:57.244011327+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -9,6 +9,12 @@ imports:
 - name: github.com/cenkalti/backoff
   version: 61153c768f31ee5f130071d08fc82b85208528de
   repo: https://github.com/cenkalti/backoff.git
+- name: github.com/facebookgo/stack
+  version: 751773369052141c013c6e827a71e8f35c07879c
+- name: github.com/fluent/fluent-logger-golang
+  version: 79368279c7a0fac229d8b29dd0e121f42d9a2cb2
+  subpackages:
+  - fluent
 - name: github.com/golang/protobuf
   version: 8ee79997227bf9b34611aee7946ae64735e6fd93
   subpackages:
@@ -17,12 +23,33 @@ imports:
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/groovenauts/blocks-variable
   version: 833d2f1e70b82c8a0a1149827906ab32aed40276
+- name: github.com/knq/jwt
+  version: 0d31af81a9cbb15756a576eef5054666a1266bb6
+  subpackages:
+  - bearer
+  - gserviceaccount
+- name: github.com/knq/pemutil
+  version: 081cdad14f5c576eab309c0de751d5f7ce4019d4
+- name: github.com/knq/sdhook
+  version: a1cc31916315b2c1a96042e3e84aa011e818dc25
+  repo: https://github.com/knq/sdhook.git
+- name: github.com/philhofer/fwd
+  version: 1612a298117663d7bc9a760ae20d383413859798
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/Sirupsen/logrus
-  version: 0208149b40d863d2c1a2f8fe5753096a9cf2cc8b
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  repo: https://github.com/sirupsen/logrus.git
+- name: github.com/tinylib/msgp
+  version: 701aacd80f9ace06ea698bd7801c361fb7fe580b
+  subpackages:
+  - msgp
 - name: github.com/urfave/cli
   version: 4b90d79a682b4bf685762c7452db20f2a676ecb2
+- name: golang.org/x/crypto
+  version: 91902e332b9d47760598861512d2ae148f94ca58
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: 69d4b8aa71caaaa75c3dfc11211d1be495abec7c
   subpackages:
@@ -48,10 +75,12 @@ imports:
 - name: google.golang.org/api
   version: b9d03e6e091e36f9a089515bc84cf14c2d199c4c
   subpackages:
+  - clouderrorreporting/v1beta1
   - gensupport
   - googleapi
   - googleapi/internal/uritemplates
   - iterator
+  - logging/v2beta1
   - pubsub
   - pubsub/v1
   - storage/v1

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8adcc5132c3de8fd9deead6e757f35e3965988cae27a92790eefb309cb58e3e0
-updated: 2017-08-17T14:58:57.244011327+09:00
+hash: c3180688ac2158da5cb46749c5907b30e7c61c01cf1597d75b3b1852634c2fe2
+updated: 2017-08-17T21:20:44.068678884+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -23,6 +23,8 @@ imports:
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
 - name: github.com/groovenauts/blocks-variable
   version: 833d2f1e70b82c8a0a1149827906ab32aed40276
+- name: github.com/Gurpartap/logrus-stack
+  version: 89c00d8a28f43c567d92eb81a2945301a6a9fbb9
 - name: github.com/knq/jwt
   version: 0d31af81a9cbb15756a576eef5054666a1266bb6
   subpackages:
@@ -31,14 +33,14 @@ imports:
 - name: github.com/knq/pemutil
   version: 081cdad14f5c576eab309c0de751d5f7ce4019d4
 - name: github.com/knq/sdhook
-  version: a1cc31916315b2c1a96042e3e84aa011e818dc25
-  repo: https://github.com/knq/sdhook.git
+  version: c63826842414963a8d536e33d13817e89fa23160
+  repo: https://github.com/groovenauts/sdhook.git
 - name: github.com/philhofer/fwd
   version: 1612a298117663d7bc9a760ae20d383413859798
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: 68806b4b77355d6c8577a2c8bbc6d547a5272491
   repo: https://github.com/sirupsen/logrus.git
 - name: github.com/tinylib/msgp
   version: 701aacd80f9ace06ea698bd7801c361fb7fe580b

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,8 +11,10 @@ import:
   - pubsub
   - pubsub/v1
   - iterator
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
+  repo: https://github.com/sirupsen/logrus.git
 - package: github.com/knq/sdhook
+  repo: https://github.com/knq/sdhook.git
 - package: github.com/satori/go.uuid
   version: ~1.1.0
 - package: github.com/cenkalti/backoff

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,6 +12,7 @@ import:
   - pubsub/v1
   - iterator
 - package: github.com/Sirupsen/logrus
+- package: github.com/knq/sdhook
 - package: github.com/satori/go.uuid
   version: ~1.1.0
 - package: github.com/cenkalti/backoff

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,9 @@ import:
 - package: github.com/sirupsen/logrus
   repo: https://github.com/sirupsen/logrus.git
 - package: github.com/knq/sdhook
-  repo: https://github.com/knq/sdhook.git
+  repo: https://github.com/groovenauts/sdhook.git
+  version: fix/error_reporting
+- package: github.com/Gurpartap/logrus-stack
 - package: github.com/satori/go.uuid
   version: ~1.1.0
 - package: github.com/cenkalti/backoff

--- a/job.go
+++ b/job.go
@@ -16,7 +16,7 @@ import (
 	"github.com/groovenauts/blocks-variable"
 	"github.com/satori/go.uuid"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type CommandConfig struct {

--- a/job.go
+++ b/job.go
@@ -25,6 +25,10 @@ type CommandConfig struct {
 	Dryrun   bool                `json:"dryrun,omitempty"`
 }
 
+func (c *CommandConfig) setup() *ConfigError {
+	return nil
+}
+
 type Job struct {
 	config *CommandConfig
 

--- a/job_message.go
+++ b/job_message.go
@@ -9,7 +9,7 @@ import (
 
 	pubsub "google.golang.org/api/pubsub/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type JobMessageStatus uint8

--- a/job_step.go
+++ b/job_step.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type JobStepStatus int

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -14,10 +14,11 @@ type JobSubscriptionConfig struct {
 	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
 }
 
-func (c *JobSubscriptionConfig) setup() {
+func (c *JobSubscriptionConfig) setup() *ConfigError {
 	if c.PullInterval == 0 {
 		c.PullInterval = 10
 	}
+	return nil
 }
 
 func (c *JobSubscriptionConfig) setupSustainer(puller Puller) error {

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -5,7 +5,7 @@ import (
 
 	pubsub "google.golang.org/api/pubsub/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type JobSubscriptionConfig struct {

--- a/log.go
+++ b/log.go
@@ -13,6 +13,7 @@ type LogConfig struct {
 func (c *LogConfig) setup() *ConfigError {
 	setups := []ConfigSetup{
 		c.setupLevel,
+		c.setupStackdriver,
 	}
 	for _, setup := range setups {
 		err := setup()
@@ -33,5 +34,16 @@ func (c *LogConfig) setupLevel() *ConfigError {
 		return &ConfigError{Name: "level", Message: fmt.Sprintf("is invalid because of %v", err)}
 	}
 	log.SetLevel(level)
+	return nil
+}
+
+func (c *LogConfig) setupStackdriver() *ConfigError {
+	if c.Stackdriver != nil {
+		err := c.Stackdriver.setup()
+		if err != nil {
+			err.Add("stackdriver")
+			return err
+		}
+	}
 	return nil
 }

--- a/log.go
+++ b/log.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type LogConfig struct {

--- a/log.go
+++ b/log.go
@@ -6,7 +6,8 @@ import (
 )
 
 type LogConfig struct {
-	Level string `json:"level,omitempty"`
+	Level       string         `json:"level,omitempty"`
+	Stackdriver *LoggingConfig `json:"stackdriver,omitempty"`
 }
 
 func (c *LogConfig) setup() *ConfigError {

--- a/log.go
+++ b/log.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -8,14 +9,27 @@ type LogConfig struct {
 	Level string `json:"level,omitempty"`
 }
 
-func (c *LogConfig) setup() error {
+func (c *LogConfig) setup() *ConfigError {
+	setups := []ConfigSetup{
+		c.setupLevel,
+	}
+	for _, setup := range setups {
+		err := setup()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *LogConfig) setupLevel() *ConfigError {
 	if c.Level == "" {
 		c.Level = "info"
 	}
 	level, err := log.ParseLevel(c.Level)
 	if err != nil {
-		log.Warnf("Invalid log level: %q\n", c.Level)
-		return err
+		log.Warnf("Error on log.ParseLevel level: %q because of %v\n", c.Level, err)
+		return &ConfigError{Name: "level", Message: fmt.Sprintf("is invalid because of %v", err)}
 	}
 	log.SetLevel(level)
 	return nil

--- a/log_test.go
+++ b/log_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/logging.go
+++ b/logging.go
@@ -1,11 +1,19 @@
 package main
 
 type LoggingConfig struct {
+	ProjectID       string						`json:"project_id"`
+	LogName		      string						`json:"log_name"`
 	Type            string            `json:"type"`
 	Labels          map[string]string `json:"labels"`
 }
 
 func (c *LoggingConfig) setup() *ConfigError {
+	if c.ProjectID == "" {
+		return &ConfigError{Name: "project_id", Message: "is required"}
+	}
+	if c.LogName == "" {
+		return &ConfigError{Name: "log_name", Message: "is required"}
+	}
 	if c.Type == "" {
 		return &ConfigError{Name: "type", Message: "is required"}
 	}

--- a/logging.go
+++ b/logging.go
@@ -12,6 +12,7 @@ type LoggingConfig struct {
 	LogName		      string						`json:"log_name"`
 	Type            string            `json:"type"`
 	Labels          map[string]string `json:"labels"`
+	ErrorReportingService string      `json:"error_reporting_service"`
 }
 
 func (c *LoggingConfig) setup() *ConfigError {
@@ -34,6 +35,9 @@ func (c *LoggingConfig) setupSdHook(client *http.Client) error {
 		sdhook.ProjectID(c.ProjectID),
 		sdhook.LogName(c.LogName),
 		sdhook.Resource(sdhook.ResType(c.Type), c.Labels),
+	}
+	if c.ErrorReportingService != "" {
+		options = append(options, sdhook.ErrorReportingService(c.ErrorReportingService))
 	}
 	hook, err := sdhook.New(options...)
 	if err != nil {

--- a/logging.go
+++ b/logging.go
@@ -4,3 +4,13 @@ type LoggingConfig struct {
 	Type            string            `json:"type"`
 	Labels          map[string]string `json:"labels"`
 }
+
+func (c *LoggingConfig) setup() *ConfigError {
+	if c.Type == "" {
+		return &ConfigError{Name: "type", Message: "is required"}
+	}
+	if c.Labels == nil {
+		return &ConfigError{Name: "labels", Message: "are required"}
+	}
+	return nil
+}

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,6 @@
+package main
+
+type LoggingConfig struct {
+	Type            string            `json:"type"`
+	Labels          map[string]string `json:"labels"`
+}

--- a/logging.go
+++ b/logging.go
@@ -8,20 +8,20 @@ import (
 )
 
 type LoggingConfig struct {
-	ProjectID       string						`json:"project_id"`
-	LogName		      string						`json:"log_name"`
-	Type            string            `json:"type"`
-	Labels          map[string]string `json:"labels"`
-	ErrorReportingService string      `json:"error_reporting_service"`
+	ProjectID             string            `json:"project_id"`
+	LogName               string            `json:"log_name"`
+	Type                  string            `json:"type"`
+	Labels                map[string]string `json:"labels"`
+	ErrorReportingService string            `json:"error_reporting_service"`
 }
 
 func (c *LoggingConfig) setup() *ConfigError {
-	for name, blank := range map[string]bool {
+	for name, blank := range map[string]bool{
 		"project_id": c.ProjectID == "",
-		"log_name": c.LogName == "",
-		"type": c.Type == "",
-		"labels": c.Labels == nil,
-	}{
+		"log_name":   c.LogName == "",
+		"type":       c.Type == "",
+		"labels":     c.Labels == nil,
+	} {
 		if blank {
 			return &ConfigError{Name: name, Message: "is required"}
 		}

--- a/logging.go
+++ b/logging.go
@@ -1,5 +1,12 @@
 package main
 
+import (
+	"net/http"
+
+	"github.com/knq/sdhook"
+	log "github.com/sirupsen/logrus"
+)
+
 type LoggingConfig struct {
 	ProjectID       string						`json:"project_id"`
 	LogName		      string						`json:"log_name"`
@@ -18,5 +25,19 @@ func (c *LoggingConfig) setup() *ConfigError {
 			return &ConfigError{Name: name, Message: "is required"}
 		}
 	}
+	return nil
+}
+
+func (c *LoggingConfig) setupSdHook(client *http.Client) error {
+	hook, err := sdhook.New(
+		sdhook.HTTPClient(client),
+		sdhook.ProjectID(c.ProjectID),
+		sdhook.LogName(c.LogName),
+		sdhook.Resource(sdhook.ResType(c.Type), c.Labels),
+	)
+	if err != nil {
+		return err
+	}
+	log.AddHook(hook)
 	return nil
 }

--- a/logging.go
+++ b/logging.go
@@ -8,17 +8,15 @@ type LoggingConfig struct {
 }
 
 func (c *LoggingConfig) setup() *ConfigError {
-	if c.ProjectID == "" {
-		return &ConfigError{Name: "project_id", Message: "is required"}
-	}
-	if c.LogName == "" {
-		return &ConfigError{Name: "log_name", Message: "is required"}
-	}
-	if c.Type == "" {
-		return &ConfigError{Name: "type", Message: "is required"}
-	}
-	if c.Labels == nil {
-		return &ConfigError{Name: "labels", Message: "are required"}
+	for name, blank := range map[string]bool {
+		"project_id": c.ProjectID == "",
+		"log_name": c.LogName == "",
+		"type": c.Type == "",
+		"labels": c.Labels == nil,
+	}{
+		if blank {
+			return &ConfigError{Name: name, Message: "is required"}
+		}
 	}
 	return nil
 }

--- a/logging.go
+++ b/logging.go
@@ -29,12 +29,13 @@ func (c *LoggingConfig) setup() *ConfigError {
 }
 
 func (c *LoggingConfig) setupSdHook(client *http.Client) error {
-	hook, err := sdhook.New(
+	options := []sdhook.Option{
 		sdhook.HTTPClient(client),
 		sdhook.ProjectID(c.ProjectID),
 		sdhook.LogName(c.LogName),
 		sdhook.Resource(sdhook.ResType(c.Type), c.Labels),
-	)
+	}
+	hook, err := sdhook.New(options...)
 	if err != nil {
 		return err
 	}

--- a/process.go
+++ b/process.go
@@ -32,18 +32,28 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
+	err := c.Command.setup()
+	if err != nil {
+		err.Add("command")
+		return err
+	}
 
 	c.Command.Template = args
 	if c.Job == nil {
 		c.Job = &JobSubscriptionConfig{}
 	}
-	c.Job.setup()
+	err = c.Job.setup()
+	if err != nil {
+		err.Add("job")
+		return err
+	}
 
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
-	err := c.Progress.setup()
+	err = c.Progress.setup()
 	if err != nil {
+		err.Add("progress")
 		return err
 	}
 
@@ -52,18 +62,28 @@ func (c *ProcessConfig) setup(args []string) error {
 	}
 	err = c.Log.setup()
 	if err != nil {
+		err.Add("log")
 		return err
 	}
 
 	if c.Download == nil {
 		c.Download = &WorkerConfig{}
 	}
-	c.Download.setup()
+	err = c.Download.setup()
+	if err != nil {
+		err.Add("download")
+		return err
+	}
 
 	if c.Upload == nil {
 		c.Upload = &WorkerConfig{}
 	}
-	c.Upload.setup()
+	err = c.Upload.setup()
+	if err != nil {
+		err.Add("upload")
+		return err
+	}
+
 	return nil
 }
 

--- a/process.go
+++ b/process.go
@@ -14,7 +14,7 @@ import (
 	pubsub "google.golang.org/api/pubsub/v1"
 	storage "google.golang.org/api/storage/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type (

--- a/process.go
+++ b/process.go
@@ -29,62 +29,67 @@ type (
 )
 
 func (c *ProcessConfig) setup(args []string) error {
+	setups := map[string]ConfigSetup{
+		"command": func()*ConfigError{
+			return c.setupCommand(args)
+		},
+		"job": c.setupJob,
+		"progress": c.setupProgress,
+		"log": c.setupLog,
+		"download": c.setupDownload,
+		"upload": c.setupUpload,
+	}
+	for key, setup := range setups {
+		err := setup()
+		if err != nil {
+			err.Add(key)
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ProcessConfig) setupCommand(args []string) *ConfigError {
 	if c.Command == nil {
 		c.Command = &CommandConfig{}
 	}
-	err := c.Command.setup()
-	if err != nil {
-		err.Add("command")
-		return err
-	}
-
 	c.Command.Template = args
+	return c.Command.setup()
+}
+
+func (c *ProcessConfig) setupJob() *ConfigError {
 	if c.Job == nil {
 		c.Job = &JobSubscriptionConfig{}
 	}
-	err = c.Job.setup()
-	if err != nil {
-		err.Add("job")
-		return err
-	}
+	return c.Job.setup()
+}
 
+func (c *ProcessConfig) setupProgress() *ConfigError {
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
-	err = c.Progress.setup()
-	if err != nil {
-		err.Add("progress")
-		return err
-	}
+	return c.Progress.setup()
+}
 
+func (c *ProcessConfig) setupLog() *ConfigError {
 	if c.Log == nil {
 		c.Log = &LogConfig{}
 	}
-	err = c.Log.setup()
-	if err != nil {
-		err.Add("log")
-		return err
-	}
+	return c.Log.setup()
+}
 
+func (c *ProcessConfig) setupDownload() *ConfigError {
 	if c.Download == nil {
 		c.Download = &WorkerConfig{}
 	}
-	err = c.Download.setup()
-	if err != nil {
-		err.Add("download")
-		return err
-	}
+	return c.Download.setup()
+}
 
+func (c *ProcessConfig) setupUpload() *ConfigError {
 	if c.Upload == nil {
 		c.Upload = &WorkerConfig{}
 	}
-	err = c.Upload.setup()
-	if err != nil {
-		err.Add("upload")
-		return err
-	}
-
-	return nil
+	return c.Upload.setup()
 }
 
 func LoadProcessConfig(path string) (*ProcessConfig, error) {

--- a/process.go
+++ b/process.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 
+	errorReporting "google.golang.org/api/clouderrorreporting/v1beta1"
 	logging "google.golang.org/api/logging/v2beta1"
 	pubsub "google.golang.org/api/pubsub/v1"
 	storage "google.golang.org/api/storage/v1"
@@ -135,7 +136,7 @@ func (p *Process) setup() error {
 	ctx := context.Background()
 
 	// https://github.com/google/google-api-go-client#application-default-credentials-example
-	client, err := google.DefaultClient(ctx, pubsub.PubsubScope, storage.DevstorageReadWriteScope, logging.LoggingWriteScope)
+	client, err := google.DefaultClient(ctx, pubsub.PubsubScope, storage.DevstorageReadWriteScope, logging.LoggingWriteScope, errorReporting.CloudPlatformScope)
 
 	if err != nil {
 		log.Fatalln("Failed to create DefaultClient")

--- a/process.go
+++ b/process.go
@@ -42,10 +42,15 @@ func (c *ProcessConfig) setup(args []string) error {
 	if c.Progress == nil {
 		c.Progress = &ProgressNotificationConfig{}
 	}
+	err := c.Progress.setup()
+	if err != nil {
+		return err
+	}
+
 	if c.Log == nil {
 		c.Log = &LogConfig{}
 	}
-	err := c.Log.setup()
+	err = c.Log.setup()
 	if err != nil {
 		return err
 	}

--- a/process.go
+++ b/process.go
@@ -30,14 +30,14 @@ type (
 
 func (c *ProcessConfig) setup(args []string) error {
 	setups := map[string]ConfigSetup{
-		"command": func()*ConfigError{
+		"command": func() *ConfigError {
 			return c.setupCommand(args)
 		},
-		"job": c.setupJob,
+		"job":      c.setupJob,
 		"progress": c.setupProgress,
-		"log": c.setupLog,
+		"log":      c.setupLog,
 		"download": c.setupDownload,
-		"upload": c.setupUpload,
+		"upload":   c.setupUpload,
 	}
 	for key, setup := range setups {
 		err := setup()

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -10,7 +10,7 @@ import (
 
 	pubsub "google.golang.org/api/pubsub/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type ProgressNotificationConfig struct {

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -19,7 +19,7 @@ type ProgressNotificationConfig struct {
 	Hostname string `json:"hostname"`
 }
 
-func (c *ProgressNotificationConfig) setup() {
+func (c *ProgressNotificationConfig) setup() *ConfigError {
 	if c.LogLevel == "" {
 		c.LogLevel = log.InfoLevel.String()
 	}
@@ -27,11 +27,12 @@ func (c *ProgressNotificationConfig) setup() {
 	if c.Hostname == "" {
 		h, err := os.Hostname()
 		if err != nil {
-			c.Hostname = "Unknown"
+			return &ConfigError{Name: "hostname", Message: "failed to get from OS"}
 		} else {
 			c.Hostname = h
 		}
 	}
+	return nil
 }
 
 type ProgressNotification struct {

--- a/progress_notification_test.go
+++ b/progress_notification_test.go
@@ -8,7 +8,7 @@ import (
 
 	pubsub "google.golang.org/api/pubsub/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/storage.go
+++ b/storage.go
@@ -6,7 +6,7 @@ import (
 
 	storage "google.golang.org/api/storage/v1"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type (

--- a/target_worker.go
+++ b/target_worker.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/cenkalti/backoff"
+	log "github.com/sirupsen/logrus"
 )
 
 type WorkerConfig struct {

--- a/target_worker.go
+++ b/target_worker.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/cenkalti/backoff"
 )
 

--- a/target_worker.go
+++ b/target_worker.go
@@ -14,10 +14,11 @@ type WorkerConfig struct {
 	MaxTries int `json:"max_tries,omitempty"`
 }
 
-func (c *WorkerConfig) setup() {
+func (c *WorkerConfig) setup() *ConfigError {
 	if c.Workers < 1 {
 		c.Workers = 1
 	}
+	return nil
 }
 
 type Target struct {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.0-alpha1"
+const VERSION = "0.7.0-alpha2"


### PR DESCRIPTION
Add `log.stackdriver` to `config.json` .
See https://github.com/groovenauts/blocks-gcs-proxy/blob/features/stackdriver_logging/README.md#configjson for more details. 

This PR depends on #62 , so see https://github.com/groovenauts/blocks-gcs-proxy/compare/18f951a38c0f...features/stackdriver_logging for actual differences.

- Add 2 packages to glide.yaml
  - github.com/knq/sdhook is the most important package in this PR
    - but it has some bugs at this time, so I sent a [PR](https://github.com/knq/sdhook/pull/7)
    - Now using [groovenauts' one](https://github.com/groovenauts/blocks-gcs-proxy/tree/features/stackdriver_logging) until the PR is merged
  - github.com/Gurpartap/logrus-stack
    - This package is required to get caller for Stackdriver Error Report Entry
