### PR TITLE
Use ACK instead of NACK

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,10 +8,6 @@ import (
 )
 
 type (
-	RetryableError interface {
-		Retryable() bool
-	}
-
 	NestableError interface {
 		CausedBy(err error) bool
 	}
@@ -49,10 +45,6 @@ func (e *InvalidJobError) Error() string {
 	return ""
 }
 
-func (e *InvalidJobError) Retryable() bool {
-	return false
-}
-
 func (e *InvalidJobError) CausedBy(err error) bool {
 	return SameErrorType(e.cause, err)
 }
@@ -69,19 +61,6 @@ func (e *CompositeError) Error() string {
 		msgs = append(msgs, err.Error())
 	}
 	return strings.Join(msgs, "\n")
-}
-
-func (e *CompositeError) Retryable() bool {
-	for _, err := range e.errors {
-		switch err.(type) {
-		case RetryableError:
-			e := err.(RetryableError)
-			if !e.Retryable() {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 func (e *CompositeError) CausedBy(err error) bool {

--- a/job.go
+++ b/job.go
@@ -63,26 +63,11 @@ func (job *Job) run() error {
 	if err == nil {
 		return nil
 	}
-	var f func() error
-	if job.retryable(err) {
-		f = job.withNotify(NACKSENDING, job.message.Nack)
-	} else {
-		f = job.withNotify(CANCELLING, job.message.Ack)
-	}
-	e := f()
+	e := job.withNotify(CANCELLING, job.message.Ack)()
 	if e != nil {
 		return e
 	}
 	return nil
-}
-
-func (job *Job) retryable(err error) bool {
-	switch err.(type) {
-	case RetryableError:
-		e := err.(RetryableError)
-		return e.Retryable()
-	}
-	return true
 }
 
 func (job *Job) runWithoutErrorHandling() error {

--- a/job_test.go
+++ b/job_test.go
@@ -54,15 +54,27 @@ func TestJobBuildNormal(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func AssertCompositeErrorWithInvalidJobError(t *testing.T, err error) bool {
+	if assert.IsType(t, (*CompositeError)(nil), err) {
+		c := err.(*CompositeError)
+		return assert.True(t, c.Any(func(e error) bool {
+			switch e.(type) {
+			case *InvalidJobError:
+				return true
+			default:
+				return false
+			}
+		}))
+	}
+	return false
+}
+
 // Invalid index for the array "download_files"
 func TestJobBuildWithInvalidIndexForArray(t *testing.T) {
 	job := NewBasicJob()
 	job.config.Template = []string{"./app.sh", "%{uploads_dir}", "%{download_files.1}"}
 	err := job.build()
-
-	if assert.Implements(t, (*RetryableError)(nil), err) {
-		assert.False(t, (err.(RetryableError)).Retryable())
-	}
+	AssertCompositeErrorWithInvalidJobError(t, err)
 }
 
 // Key string is given for the array "download_files"
@@ -70,9 +82,7 @@ func TestJobBuildWithStringKeyForArray(t *testing.T) {
 	job := NewBasicJob()
 	job.config.Template = []string{"./app.sh", "%{uploads_dir}", "%{download_files.foo}"}
 	err := job.build()
-	if assert.Implements(t, (*RetryableError)(nil), err) {
-		assert.False(t, (err.(RetryableError)).Retryable())
-	}
+	AssertCompositeErrorWithInvalidJobError(t, err)
 }
 
 // Invalid key given for the map "download_files"
@@ -83,9 +93,7 @@ func TestJobBuildWithInvalidKeyForMap(t *testing.T) {
 		"foo": downloads_dir + "/bucket1/foo",
 	}
 	err := job.build()
-	if assert.Implements(t, (*RetryableError)(nil), err) {
-		assert.False(t, (err.(RetryableError)).Retryable())
-	}
+	AssertCompositeErrorWithInvalidJobError(t, err)
 }
 
 // Invalid index and invalid key for the array and map in attrs
@@ -93,9 +101,7 @@ func TestJobBuildWithInvalidIndexAndKeyInAttrs(t *testing.T) {
 	job := NewBasicJob()
 	job.config.Template = []string{"echo", "%{attrs.array.3}", "%{attrs.map.bar}"}
 	err := job.build()
-	if assert.Implements(t, (*RetryableError)(nil), err) {
-		assert.False(t, (err.(RetryableError)).Retryable())
-	}
+	AssertCompositeErrorWithInvalidJobError(t, err)
 	assert.Regexp(t, "Invalid index 3", err.Error())
 	assert.Regexp(t, "Invalid key bar", err.Error())
 }
@@ -107,9 +113,7 @@ func TestJobBuildWithInvalidDownloadFilesReference(t *testing.T) {
 	job.localDownloadFiles = nil
 	err := job.build()
 	if assert.Error(t, err) {
-		if assert.Implements(t, (*RetryableError)(nil), err) {
-			assert.False(t, (err.(RetryableError)).Retryable())
-		}
+		AssertCompositeErrorWithInvalidJobError(t, err)
 		assert.Regexp(t, "No value found", err.Error())
 		assert.Regexp(t, "download_files", err.Error())
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.1-alpha1"
+const VERSION = "0.7.1-alpha2"


### PR DESCRIPTION
At the first time, We had to repeat failure job by using NACK, but now we can retry with [github.com/cenkalti/backoff](https://github.com/cenkalti/backoff). And application job doesn't need retry after failure. So now we don't need NACK. This PR remove the features to send NACK.

- Remove `RetryableError` interface
- Return ACK instead of NACK at the end of job
