### PR TITLE
Add zone, host, start time and finish time to progress notification messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ specified by `job.subscription` in `config.json`.
 | progress | map | True |  |  |
 | progress.topic | string | True | - | The topic name to publish job progress messages |
 | progress.level | string | False | `info` | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
-| progress.hostname | string | False | (hostname) | Hostname attribute value of job progress message |
+| progress.attributes | map[string]string | False | {} | Static attributes of progress notification message |
 | log       | map    | False |  |  |
 | log.level | string | False | `info` | Log level of processing of `blocks-gcs-proxy`. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |
 | log.command_severity | string | False | `info` | The Log severity of command outputs. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |

--- a/job.go
+++ b/job.go
@@ -74,6 +74,12 @@ func (job *Job) run() error {
 		if e != nil {
 			return e
 		}
+	} else {
+		job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
+		e = job.withNotify(ACKSENDING, job.message.Ack)()
+		if e != nil {
+			return e
+		}
 	}
 	return nil
 }
@@ -100,12 +106,6 @@ func (job *Job) runWithoutErrorHandling() error {
 	}
 
 	err = job.withNotify(UPLOADING, job.uploadFiles)()
-	if err != nil {
-		return err
-	}
-
-	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
-	err = job.withNotify(ACKSENDING, job.message.Ack)()
 	if err != nil {
 		return err
 	}

--- a/job.go
+++ b/job.go
@@ -67,13 +67,13 @@ const (
 func (job *Job) run() error {
 	job.message.raw.Message.Attributes[StartTimeKey] = time.Now().Format(time.RFC3339)
 	err := job.runWithoutErrorHandling()
-	if err == nil {
-		return nil
-	}
-	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
-	e := job.withNotify(CANCELLING, job.message.Ack)()
-	if e != nil {
-		return e
+	if err != nil {
+		// Notify CANCELLING insted of return err
+		job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
+		e := job.withNotify(CANCELLING, job.message.Ack)()
+		if e != nil {
+			return e
+		}
 	}
 	return nil
 }

--- a/job.go
+++ b/job.go
@@ -104,6 +104,7 @@ func (job *Job) runWithoutErrorHandling() error {
 		return err
 	}
 
+	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 	err = job.withNotify(ACKSENDING, job.message.Ack)()
 	if err != nil {
 		return err

--- a/job.go
+++ b/job.go
@@ -67,15 +67,14 @@ const (
 func (job *Job) run() error {
 	job.message.raw.Message.Attributes[StartTimeKey] = time.Now().Format(time.RFC3339)
 	err := job.runWithoutErrorHandling()
+	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 	if err != nil {
 		// Notify CANCELLING insted of return err
-		job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 		e := job.withNotify(CANCELLING, job.message.Ack)()
 		if e != nil {
 			return e
 		}
 	} else {
-		job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 		e = job.withNotify(ACKSENDING, job.message.Ack)()
 		if e != nil {
 			return e

--- a/job.go
+++ b/job.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/groovenauts/blocks-variable"
 	"github.com/satori/go.uuid"
@@ -58,11 +59,18 @@ type Job struct {
 	cmd *exec.Cmd
 }
 
+const (
+	StartTimeKey  = "job.start-time"
+	FinishTimeKey = "job.finish-time"
+)
+
 func (job *Job) run() error {
+	job.message.raw.Message.Attributes[StartTimeKey] = time.Now().Format(time.RFC3339)
 	err := job.runWithoutErrorHandling()
 	if err == nil {
 		return nil
 	}
+	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 	e := job.withNotify(CANCELLING, job.message.Ack)()
 	if e != nil {
 		return e

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"os"
 	"strconv"
 
 	// "golang.org/x/net/context"
@@ -14,23 +13,14 @@ import (
 )
 
 type ProgressNotificationConfig struct {
-	Topic    string `json:"topic"`
-	LogLevel string `json:"log_level"`
-	Hostname string `json:"hostname"`
+	Topic      string            `json:"topic"`
+	LogLevel   string            `json:"log_level"`
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 func (c *ProgressNotificationConfig) setup() *ConfigError {
 	if c.LogLevel == "" {
 		c.LogLevel = logrus.InfoLevel.String()
-	}
-
-	if c.Hostname == "" {
-		h, err := os.Hostname()
-		if err != nil {
-			return &ConfigError{Name: "hostname", Message: "failed to get from OS"}
-		} else {
-			c.Hostname = h
-		}
 	}
 	return nil
 }
@@ -76,13 +66,13 @@ func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progr
 		return nil
 	}
 	attrs := map[string]string{}
+	pn.mergeMsgAttrs(attrs, pn.config.Attributes)
 	pn.mergeMsgAttrs(attrs, opts)
 	pn.mergeMsgAttrs(attrs, map[string]string{
 		"progress":       strconv.Itoa(int(progress)),
 		"completed":      strconv.FormatBool(completed),
 		"job_message_id": job_msg_id,
 		"level":          level.String(),
-		"host":           pn.config.Hostname,
 	})
 	logAttrs := logrus.Fields{}
 	for k, v := range attrs {

--- a/progress_notification.go
+++ b/progress_notification.go
@@ -76,19 +76,14 @@ func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progr
 		return nil
 	}
 	attrs := map[string]string{}
-	for k, v := range opts {
-		buf := []byte(v)
-		if len(buf) > 1024 {
-			attrs[k] = string(buf[0:1024])
-		} else {
-			attrs[k] = v
-		}
-	}
-	attrs["progress"] = strconv.Itoa(int(progress))
-	attrs["completed"] = strconv.FormatBool(completed)
-	attrs["job_message_id"] = job_msg_id
-	attrs["level"] = level.String()
-	attrs["host"] = pn.config.Hostname
+	pn.mergeMsgAttrs(attrs, opts)
+	pn.mergeMsgAttrs(attrs, map[string]string{
+		"progress":       strconv.Itoa(int(progress)),
+		"completed":      strconv.FormatBool(completed),
+		"job_message_id": job_msg_id,
+		"level":          level.String(),
+		"host":           pn.config.Hostname,
+	})
 	logAttrs := logrus.Fields{}
 	for k, v := range attrs {
 		logAttrs[k] = v
@@ -102,4 +97,15 @@ func (pn *ProgressNotification) notifyProgress(job_msg_id string, progress Progr
 		return err
 	}
 	return nil
+}
+
+func (pn *ProgressNotification) mergeMsgAttrs(dest, src map[string]string) {
+	for k, v := range src {
+		buf := []byte(v)
+		if len(buf) > 1024 {
+			dest[k] = string(buf[0:1024])
+		} else {
+			dest[k] = v
+		}
+	}
 }

--- a/progress_notification_test.go
+++ b/progress_notification_test.go
@@ -49,7 +49,9 @@ func TestProgressNotificationNotify(t *testing.T) {
 	config := ProgressNotificationConfig{
 		Topic:    DummyTopic,
 		LogLevel: "info",
-		Hostname: DummyHost,
+		Attributes: map[string]string{
+			"host": DummyHost,
+		},
 	}
 
 	notification := ProgressNotification{

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.2-alpha1"
+const VERSION = "0.7.2-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.1"
+const VERSION = "0.7.2-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.2-alpha2"
+const VERSION = "0.7.2"


### PR DESCRIPTION
Add the following data to progress notification messages
- `zone` and `host` [to make debugging easy](https://github.com/groovenauts/blocks-concurrent-batch-agent/issues/52)
- `job.start-time` and `job.finish-time` [to record job performance reasons](https://github.com/groovenauts/blocks-concurrent-batch-agent/issues/56)
