### PR TITLE
Add concurrent_batch_job_id to logrus fields

### DIFF
--- a/job_message.go
+++ b/job_message.go
@@ -63,6 +63,12 @@ func (m *JobMessage) MessageId() string {
 	return m.raw.Message.MessageId
 }
 
+const ConcurrentBatchJobIdKey = "concurrent_batch.job_id"
+
+func (m *JobMessage) ConcurrentBatchJobId() string {
+	return m.raw.Message.Attributes[ConcurrentBatchJobIdKey]
+}
+
 func (m *JobMessage) InsertExecUUID() {
 }
 

--- a/job_message.go
+++ b/job_message.go
@@ -64,7 +64,7 @@ func (m *JobMessage) MessageId() string {
 }
 
 const (
-	ConcurrentBatchJobIdKey = "concurrent_batch.job_id"
+	ConcurrentBatchJobIdKey     = "concurrent_batch.job_id"
 	ConcurrentBatchJobIdKey4Log = "concurrent_batch_job_id"
 )
 

--- a/job_message.go
+++ b/job_message.go
@@ -63,7 +63,10 @@ func (m *JobMessage) MessageId() string {
 	return m.raw.Message.MessageId
 }
 
-const ConcurrentBatchJobIdKey = "concurrent_batch.job_id"
+const (
+	ConcurrentBatchJobIdKey = "concurrent_batch.job_id"
+	ConcurrentBatchJobIdKey4Log = "concurrent_batch_job_id"
+)
 
 func (m *JobMessage) ConcurrentBatchJobId() string {
 	return m.raw.Message.Attributes[ConcurrentBatchJobIdKey]

--- a/process.go
+++ b/process.go
@@ -122,7 +122,7 @@ func (p *Process) run() error {
 			storage:              p.storage,
 		}
 		job.setupExecUUID()
-		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId()})
+		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), ConcurrentBatchJobIdKey: msg.ConcurrentBatchJobId()})
 		err := p.replaceGlobalLog(jobLog, func() error {
 			err := job.run()
 			if err != nil {

--- a/process.go
+++ b/process.go
@@ -122,7 +122,7 @@ func (p *Process) run() error {
 			storage:              p.storage,
 		}
 		job.setupExecUUID()
-		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), "ack-id": msg.raw.AckId})
+		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId()})
 		err := p.replaceGlobalLog(jobLog, func() error {
 			err := job.run()
 			if err != nil {

--- a/process.go
+++ b/process.go
@@ -122,7 +122,7 @@ func (p *Process) run() error {
 			storage:              p.storage,
 		}
 		job.setupExecUUID()
-		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), ConcurrentBatchJobIdKey: msg.ConcurrentBatchJobId()})
+		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), ConcurrentBatchJobIdKey4Log: msg.ConcurrentBatchJobId()})
 		err := p.replaceGlobalLog(jobLog, func() error {
 			err := job.run()
 			if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.2"
+const VERSION = "0.7.3-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.3-alpha2"
+const VERSION = "0.7.3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.3-alpha1"
+const VERSION = "0.7.3-alpha2"


### PR DESCRIPTION
Add `concurrent_batch_job_id` to logrus fields to specify the logs by Job ID of `blocks-concurrent-batch-agent`.
And remove `ack-id` from logrus fields because it's too long (160 bytes).

@nagachika @minimum2scp @taigou @guemon 
I don't add you to this reviewers because I need this PR merge soon.
Let me know if you find something wrong or suspicious.
