### PR TITLE
Add content-type-by-ext option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,15 @@ specified by `job.subscription` in `config.json`.
 | command   | map | False |  |  |
 | command.dryrun | bool | False | `false` | Don't run the command if this is true. |
 | command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
-| download           | map | False |  |  |
-| download.workers   | int | False | 1 | The number of thread to download. |
-| download.max_tries | int | False | 0 | The number of tries to download. |
-| upload           | map | False |  |  |
-| upload.workers   | int | False | 1 | The number of thread to upload. |
-| upload.max_tries | int | False | 0 | The number of tries to upload. |
+| download                  | map | False |  |  |
+| download.worker           | map | False |  |  |
+| download.worker.workers   | int | False | 1 | The number of thread to download. |
+| download.worker.max_tries | int | False | 0 | The number of tries to download. |
+| upload                  | map | False |  |  |
+| upload.worker           | map | False |  |  |
+| upload.worker.workers   | int | False | 1 | The number of thread to upload. |
+| upload.worker.max_tries | int | False | 0 | The number of tries to upload. |
+| upload.content_type_by_ext | bool | False |  | Set content type by file extension when uploading to GCS |
 
 
 ### Multiple command options

--- a/cli_actions.go
+++ b/cli_actions.go
@@ -145,8 +145,8 @@ func (act *CliActions) DownloadCommand() cli.Command {
 
 func (act *CliActions) Download(c *cli.Context) error {
 	config := act.LoadAndSetupProcessConfigWith(c, func(cfg *ProcessConfig) error {
-		cfg.Download.Workers = c.Int(flag_workers)
-		cfg.Download.MaxTries = c.Int(flag_max_tries)
+		cfg.Download.Worker.Workers = c.Int(flag_workers)
+		cfg.Download.Worker.MaxTries = c.Int(flag_max_tries)
 		cfg.Job.Sustainer = &JobSustainerConfig{
 			Disabled: true,
 		}
@@ -200,8 +200,8 @@ func (act *CliActions) UploadCommand() cli.Command {
 func (act *CliActions) Upload(c *cli.Context) error {
 	fmt.Printf("Uploading files\n")
 	config := act.LoadAndSetupProcessConfigWith(c, func(cfg *ProcessConfig) error {
-		cfg.Upload.Workers = c.Int(flag_workers)
-		cfg.Upload.MaxTries = c.Int(flag_max_tries)
+		cfg.Upload.Worker.Workers = c.Int(flag_workers)
+		cfg.Upload.Worker.MaxTries = c.Int(flag_max_tries)
 		cfg.Job.Sustainer = &JobSustainerConfig{
 			Disabled: true,
 		}

--- a/cli_actions.go
+++ b/cli_actions.go
@@ -13,15 +13,16 @@ import (
 )
 
 const (
-	flag_config        = "config"
-	flag_log_config    = "log-config"
-	flag_workers       = "workers"
-	flag_max_tries     = "max_tries"
-	flag_wait          = "wait"
-	flag_downloads_dir = "downloads_dir"
-	flag_uploads_dir   = "uploads_dir"
-	flag_message       = "message"
-	flag_workspace     = "workspace"
+	flag_config              = "config"
+	flag_log_config          = "log-config"
+	flag_workers             = "workers"
+	flag_max_tries           = "max_tries"
+	flag_wait                = "wait"
+	flag_downloads_dir       = "downloads_dir"
+	flag_uploads_dir         = "uploads_dir"
+	flag_content_type_by_ext = "content_type_by_ext"
+	flag_message             = "message"
+	flag_workspace           = "workspace"
 )
 
 var flagAliases = map[string]string{
@@ -190,6 +191,10 @@ func (act *CliActions) UploadCommand() cli.Command {
 				Name:  act.flagName(flag_uploads_dir),
 				Usage: "Path to the directory which has bucket_name/path/to/file",
 			},
+			cli.BoolFlag{
+				Name:  act.flagName(flag_content_type_by_ext),
+				Usage: "Set Content-Type by file extension with /etc/mime.types, /etc/apache2/mime.types or /etc/apache/mime.types",
+			},
 			act.flagWorkers(),
 			act.flagMaxTries(),
 			act.flagWait(),
@@ -200,6 +205,7 @@ func (act *CliActions) UploadCommand() cli.Command {
 func (act *CliActions) Upload(c *cli.Context) error {
 	fmt.Printf("Uploading files\n")
 	config := act.LoadAndSetupProcessConfigWith(c, func(cfg *ProcessConfig) error {
+		cfg.Upload.ContentTypeByExt = c.Bool(flag_content_type_by_ext)
 		cfg.Upload.Worker.Workers = c.Int(flag_workers)
 		cfg.Upload.Worker.MaxTries = c.Int(flag_max_tries)
 		cfg.Job.Sustainer = &JobSustainerConfig{

--- a/job.go
+++ b/job.go
@@ -35,8 +35,8 @@ type Job struct {
 
 	commandSeverityLevel logrus.Level // From LogConfig
 
-	downloadConfig *WorkerConfig
-	uploadConfig   *WorkerConfig
+	downloadConfig *DownloadConfig
+	uploadConfig   *UploadConfig
 
 	// https://godoc.org/google.golang.org/genproto/googleapis/pubsub/v1#ReceivedMessage
 	message      *JobMessage
@@ -413,11 +413,11 @@ func (job *Job) downloadFiles() error {
 	log.WithFields(logrus.Fields{"targets": targets}).Debugln("Download Prepared")
 
 	downloaders := TargetWorkers{}
-	for i := 0; i < job.downloadConfig.Workers; i++ {
+	for i := 0; i < job.downloadConfig.Worker.Workers; i++ {
 		downloader := &TargetWorker{
 			name:     "downoad",
 			impl:     job.storage.Download,
-			maxTries: job.downloadConfig.MaxTries,
+			maxTries: job.downloadConfig.Worker.MaxTries,
 		}
 		downloaders = append(downloaders, downloader)
 	}
@@ -467,11 +467,11 @@ func (job *Job) uploadFiles() error {
 	log.WithFields(logrus.Fields{"targets": targets}).Debugln("Upload Prepared")
 
 	uploaders := TargetWorkers{}
-	for i := 0; i < job.uploadConfig.Workers; i++ {
+	for i := 0; i < job.uploadConfig.Worker.Workers; i++ {
 		uploader := &TargetWorker{
 			name:     "upload",
 			impl:     job.storage.Upload,
-			maxTries: job.uploadConfig.MaxTries,
+			maxTries: job.uploadConfig.Worker.MaxTries,
 		}
 		uploaders = append(uploaders, uploader)
 	}

--- a/process.go
+++ b/process.go
@@ -52,7 +52,10 @@ func (p *Process) setup() error {
 		log.WithFields(logAttrs).Fatalln("Failed to create storage.Service")
 		return err
 	}
-	p.storage = &CloudStorage{storageService.Objects}
+	p.storage = &CloudStorage{
+		service:          storageService.Objects,
+		ContentTypeByExt: p.config.Upload.ContentTypeByExt,
+	}
 
 	// Creates a pubsubService
 	pubsubService, err := pubsub.New(client)

--- a/process_config.go
+++ b/process_config.go
@@ -15,8 +15,8 @@ type (
 		Job      *JobSubscriptionConfig      `json:"job,omitempty"`
 		Progress *ProgressNotificationConfig `json:"progress,omitempty"`
 		Log      *LogConfig                  `json:"log,omitempty"`
-		Download *WorkerConfig               `json:"download"`
-		Upload   *WorkerConfig               `json:"upload"`
+		Download *DownloadConfig             `json:"download"`
+		Upload   *UploadConfig               `json:"upload"`
 	}
 )
 
@@ -72,16 +72,20 @@ func (c *ProcessConfig) setupLog() *ConfigError {
 
 func (c *ProcessConfig) setupDownload() *ConfigError {
 	if c.Download == nil {
-		c.Download = &WorkerConfig{}
+		c.Download = &DownloadConfig{
+			Worker: &WorkerConfig{},
+		}
 	}
-	return c.Download.setup()
+	return c.Download.Worker.setup()
 }
 
 func (c *ProcessConfig) setupUpload() *ConfigError {
 	if c.Upload == nil {
-		c.Upload = &WorkerConfig{}
+		c.Upload = &UploadConfig{
+			Worker: &WorkerConfig{},
+		}
 	}
-	return c.Upload.setup()
+	return c.Upload.Worker.setup()
 }
 
 func LoadProcessConfig(path string) (*ProcessConfig, error) {

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -117,7 +117,7 @@ func TestLoadProcessConfigWithDefaultValues(t *testing.T) {
 			assert.Equal(t, float64(600), config.Job.Sustainer.Delay)
 			assert.Equal(t, float64(540), config.Job.Sustainer.Interval)
 			assert.Equal(t, fmt.Sprintf("projects/%v/topics/%v-progress-topic", proj, pipeline), config.Progress.Topic)
-			assert.Equal(t, int(8), config.Upload.Workers)
+			assert.Equal(t, int(8), config.Upload.Worker.Workers)
 		}
 	})
 }

--- a/storage.go
+++ b/storage.go
@@ -9,6 +9,14 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
+type DownloadConfig struct {
+	Worker *WorkerConfig `json:"worker,omitempty"`
+}
+
+type UploadConfig struct {
+	Worker *WorkerConfig `json:"worker,omitempty"`
+}
+
 type (
 	Storage interface {
 		Download(bucket, object, destPath string) error

--- a/storage.go
+++ b/storage.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"io"
+	"mime"
 	"os"
+	"path"
 
 	storage "google.golang.org/api/storage/v1"
 
@@ -14,7 +16,8 @@ type DownloadConfig struct {
 }
 
 type UploadConfig struct {
-	Worker *WorkerConfig `json:"worker,omitempty"`
+	Worker           *WorkerConfig `json:"worker,omitempty"`
+	ContentTypeByExt bool          `json:"content_type_by_ext,omitempty"`
 }
 
 type (
@@ -24,7 +27,8 @@ type (
 	}
 
 	CloudStorage struct {
-		service *storage.ObjectsService
+		service          *storage.ObjectsService
+		ContentTypeByExt bool
 	}
 )
 
@@ -62,7 +66,11 @@ func (ct *CloudStorage) Upload(bucket, object, srcPath string) error {
 		log.WithFields(logrus.Fields{"error": err}).Warnf("Failed to open the file")
 		return err
 	}
-	_, err = ct.service.Insert(bucket, &storage.Object{Name: object}).Media(f).Do()
+	obj := &storage.Object{Name: object}
+	if ct.ContentTypeByExt {
+		obj.ContentType = mime.TypeByExtension(path.Ext(object))
+	}
+	_, err = ct.service.Insert(bucket, obj).Media(f).Do()
 	if err != nil {
 		log.WithFields(logrus.Fields{"error": err}).Warnf("Failed to upload")
 		return err

--- a/test/config_with_env_and_default3.json
+++ b/test/config_with_env_and_default3.json
@@ -17,6 +17,8 @@
     "topic": "projects/{{ .GCP_PROJECT }}/topics/{{ or .PIPELINE "pipeline01" }}-progress-topic"
   },
   "upload": {
-    "workers": {{ or .UPLOADERS 8}}
+    "worker": {
+      "workers": {{ or .UPLOADERS 8}}
+    }
   }
 }

--- a/test/full.json
+++ b/test/full.json
@@ -22,11 +22,15 @@
     "level": "debug"
   },
   "download": {
-    "workers": 5,
-    "max_tries": 6
+    "worker": {
+      "workers": 5,
+      "max_tries": 6
+    }
   },
   "upload": {
-    "workers": 8,
-    "max_tries": 9
+    "worker": {
+      "workers": 8,
+      "max_tries": 9
+    }
   }
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.3"
+const VERSION = "0.8.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.8.0-alpha1"
+const VERSION = "0.8.0"


### PR DESCRIPTION
`content-type`  of the files uploaded by current implementation is `text/plain` instead of `application/octet-stream` explained in [this document](https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body) 

![screen shot 2017-11-15 at 19 53 00](https://user-images.githubusercontent.com/18912/32832393-a37136b8-ca3e-11e7-8b6a-6e02967b3187.png)

This PR provides the feature to set `content-type` from file extension by using [mime.TypeByExtension](https://golang.org/pkg/mime/#TypeByExtension) which refers the following files:

- /etc/mime.types
- /etc/apache2/mime.types
- /etc/apache/mime.types

## config.json changes

This PR modify `config.json` format, so bump up the minor version to 0.8.0 .
