### PR TITLE
Update library versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,8 +3,9 @@
 
 [[projects]]
   name = "cloud.google.com/go"
-  packages = ["compute/metadata","internal"]
-  revision = "81b7822b1e798e8f17bf64b59512a5be4097e966"
+  packages = ["compute/metadata"]
+  revision = "056a55f54a6cc77b440b31a56a5e7c3982d32811"
+  version = "v0.22.0"
 
 [[projects]]
   branch = "master"
@@ -15,14 +16,15 @@
 [[projects]]
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
   source = "https://github.com/cenkalti/backoff.git"
-  version = "v1.1.0"
+  version = "v2.0.0"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "04cdfd42973bb9c8589fd6a731800cf222fde1a9"
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -33,17 +35,14 @@
 [[projects]]
   name = "github.com/fluent/fluent-logger-golang"
   packages = ["fluent"]
-  revision = "79368279c7a0fac229d8b29dd0e121f42d9a2cb2"
+  revision = "8bbc2356beaf021b04c9bd5cdc76ea5a7ccb40ec"
+  version = "v1.3.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "8ee79997227bf9b34611aee7946ae64735e6fd93"
-
-[[projects]]
-  name = "github.com/googleapis/gax-go"
-  packages = ["."]
-  revision = "da06d194a00e19ce00d9011a13931c3f6f6887c7"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -58,14 +57,16 @@
   version = "0.0.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/knq/jwt"
   packages = [".","bearer","gserviceaccount"]
-  revision = "0d31af81a9cbb15756a576eef5054666a1266bb6"
+  revision = "b171e76ef80432a5f261ff6e695b63bbdb17e2c8"
 
 [[projects]]
+  branch = "master"
   name = "github.com/knq/pemutil"
   packages = ["."]
-  revision = "081cdad14f5c576eab309c0de751d5f7ce4019d4"
+  revision = "e7ebaf079fb4b0fc071be79e23c25bc41ee283e9"
 
 [[projects]]
   branch = "fix/error_reporting"
@@ -77,12 +78,14 @@
 [[projects]]
   name = "github.com/philhofer/fwd"
   packages = ["."]
-  revision = "1612a298117663d7bc9a760ae20d383413859798"
+  revision = "bb6d471dc95d4fe11e432687f8b70ff496cf3136"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
-  revision = "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -93,58 +96,63 @@
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "68806b4b77355d6c8577a2c8bbc6d547a5272491"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   source = "https://github.com/sirupsen/logrus.git"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "2402e8e7a02fc811447d11f881aa9746cdc57983"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   name = "github.com/tinylib/msgp"
   packages = ["msgp"]
-  revision = "701aacd80f9ace06ea698bd7801c361fb7fe580b"
+  revision = "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1"
+  version = "1.0.2"
 
 [[projects]]
   name = "github.com/urfave/cli"
   packages = ["."]
-  revision = "4b90d79a682b4bf685762c7452db20f2a676ecb2"
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "91902e332b9d47760598861512d2ae148f94ca58"
+  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "69d4b8aa71caaaa75c3dfc11211d1be495abec7c"
+  packages = ["context","context/ctxhttp"]
+  revision = "2491c5de3490fced2f6cff376127c667efeed857"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/oauth2"
   packages = [".","google","internal","jws","jwt"]
-  revision = "314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd"
+  revision = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "d75a52659825e75fff6158388dddc6a5b04f9ba5"
+  packages = ["unix","windows"]
+  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
 
 [[projects]]
+  branch = "master"
   name = "google.golang.org/api"
   packages = ["clouderrorreporting/v1beta1","gensupport","googleapi","googleapi/internal/uritemplates","logging/v2beta1","pubsub/v1","storage/v1"]
-  revision = "b9d03e6e091e36f9a089515bc84cf14c2d199c4c"
+  revision = "d7aa31fbd7da4467a8056610e654315a4c1f068e"
 
 [[projects]]
   name = "google.golang.org/appengine"
   packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
-  revision = "08a149cfaee099e6ce4be01c0113a78c85ee1dee"
-
-[[projects]]
-  name = "google.golang.org/grpc"
-  packages = [".","codes","credentials","grpclog","internal","metadata","naming","peer","stats","tap","transport"]
-  revision = "50955793b0183f9de69bd78e2ec251cf20aab121"
+  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
+  version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/examples/ruby/job.json
+++ b/examples/ruby/job.json
@@ -1,5 +1,4 @@
 {
-  "id_by_client": "dummy-job1",
   "message":{
     "attributes":{
       "download_files":"[\"gs://blocks-gcs-proxy-test1/images/GitX-dev.dmg\"]"

--- a/process.go
+++ b/process.go
@@ -67,7 +67,7 @@ func (p *Process) setup() error {
 
 	eb := backoff.NewExponentialBackOff()
 	eb.InitialInterval = 10 * time.Second
-	b := backoff.WithMaxTries(eb, 5)
+	b := backoff.WithMaxRetries(eb, 5)
 	puller := &BackoffPuller{
 		Impl:    &pubsubPuller{pubsubService.Projects.Subscriptions},
 		Backoff: b,

--- a/target_worker.go
+++ b/target_worker.go
@@ -48,7 +48,7 @@ func (w *RetryableFunc) Wrap(orig func(*concurrent.Job) error) func(*concurrent.
 
 		eb := backoff.NewExponentialBackOff()
 		eb.InitialInterval = w.interval
-		b := backoff.WithMaxTries(eb, uint64(w.maxTries))
+		b := backoff.WithMaxRetries(eb, uint64(w.maxTries))
 		// err := backoff.Retry(f, b)
 		err := RetryWithSleep(f, b)
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.8.2"
+const VERSION = "0.8.3-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.8.3-alpha1"
+const VERSION = "0.8.3"


### PR DESCRIPTION
- Update Gopkg.lock
- Update usages of `backoff` library
- Remove unnecessary description from an example of `job.json`
