### PR TITLE
Send outputs to blocks-concurrent-batch-agent on error

### DIFF
--- a/job.go
+++ b/job.go
@@ -341,9 +341,10 @@ func (job *Job) build() error {
 	}
 	w := &LogrusWriter{Dest: log, Severity: job.commandSeverityLevel}
 	w.Setup()
-	job.cmd = exec.Command(values[0], values[1:]...)
-	job.cmd.Stdout = w
-	job.cmd.Stderr = w
+	cmd := exec.Command(values[0], values[1:]...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	job.cmd = cmd
 	log.WithFields(logrus.Fields{"job.cmd": job.cmd}).Debugln("Job#build has done")
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.0-alpha1"
+const VERSION = "0.9.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.8.3"
+const VERSION = "0.9.0-alpha1"

--- a/writer_ext.go
+++ b/writer_ext.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"io"
+)
+
+type CompositeWriter struct {
+	Main io.Writer
+	Sub  io.Writer
+}
+
+func (cw *CompositeWriter) Write(p []byte) (int, error) {
+	n, err := cw.Main.Write(p)
+	cw.Sub.Write(p)
+	return n, err
+}


### PR DESCRIPTION
- Add `CompositeWriter` type
    - To write logs to both log file and buffer
- Keep outputs to stdout/stderr into buffer
- Send outputs from buffer to blocks-concurrent-batch-agent on error