### PR TITLE
Add config to return NACK on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ specified by `job.subscription` in `config.json`.
 | job     | map | False |  |  |
 | job.subscription | string | False | `projects/{{ .GCP_PROJECT }}/subscriptions/{{ .PIPELINE }}-job-subscription` | The subscription name to pull job messages |
 | job.pull_interval | int | False | 10 | The interval time in second to pull when it gets no job message. |
+| job.nack_on_error | bool | False | False | Send NACK on error instead of ACK |
 | job.sustainer     | map | False |  |  |
 | job.sustainer.delay | int | False | See [Sustainer](#sustainer) | The new deadline in second to extend deadline to ack |
 | job.sustainer.interval | int | False | See [Sustainer](#sustainer) | The interval in second to send the message which extends deadline to ack |

--- a/examples/error_handling/.gitignore
+++ b/examples/error_handling/.gitignore
@@ -1,0 +1,1 @@
+/blocks-gcs-proxy

--- a/examples/error_handling/README.md
+++ b/examples/error_handling/README.md
@@ -2,9 +2,11 @@
 
 ## Setup
 
-Start pubsub emulator in a new terminal.
-
 ```bash
+$ cd path/to/blocks-gcs-proxy
+$ export BLOCKS_GCS_PROXY_VERSION=$(make version)
+$ cd examples/error_handling
+$ export BLOCKS_GCS_PROXY_VERSION=$(make version)
 $ export GCP_PROJECT=[YOUR PROJECT]
 $ export PUBSUB_BASE_NAME=test1
 $ export PUBSUB_TOPIC=$PUBSUB_BASE_NAME-topic
@@ -16,11 +18,17 @@ $ gcloud --project $GCP_PROJECT pubsub subscriptions list
 ```
 
 ```
-$ export BLOCKS_GCS_PROXY_VERSION=$(make version)
-$ curl -L --output ./blocks-gcs-proxy https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64
+$ export BLOCKS_GCS_PROXY_FILE=blocks-gcs-proxy_darwin_amd64
+```
+
+```
+$ export BLOCKS_GCS_PROXY_FILE=blocks-gcs-proxy_linux_amd64
+```
+
+```
+$ curl -L --output ./blocks-gcs-proxy https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/$BLOCKS_GCS_PROXY_FILE
 $ chmod +x ./blocks-gcs-proxy
 $ ./blocks-gcs-proxy --version
-
 
 
 ## Without NackOnError
@@ -28,7 +36,7 @@ $ ./blocks-gcs-proxy --version
 Start blocks-gcs-proxy with app.rb
 
 ```
-$ ./blocks-gcs-proxy --config config_without_nack_on_error.json app.rb %{attrs.exit_code}
+$ ./blocks-gcs-proxy --config config_without_nack_on_error.json ./app.rb %{attrs.exit_code}
 ```
 
 Send messages from another terminal.
@@ -46,7 +54,7 @@ Each of the messages must show you that app.rb is called once.
 Start blocks-gcs-proxy with app.rb
 
 ```
-$ ./blocks-gcs-proxy --config config_with_nack_on_error.json app.rb %{attrs.exit_code}
+$ ./blocks-gcs-proxy --config config_with_nack_on_error.json ./app.rb %{attrs.exit_code}
 ```
 
 Send messages from another terminal.
@@ -57,3 +65,4 @@ $ gcloud --project $GCP_PROJECT pubsub topics publish projects/$GCP_PROJECT/topi
 ```
 
 The 2nd message must show you that app.rb is called repeatedly.
+Stop the process by `Ctrl+C`.

--- a/examples/error_handling/README.md
+++ b/examples/error_handling/README.md
@@ -1,0 +1,59 @@
+# error handling example
+
+## Setup
+
+Start pubsub emulator in a new terminal.
+
+```bash
+$ export GCP_PROJECT=[YOUR PROJECT]
+$ export PUBSUB_BASE_NAME=test1
+$ export PUBSUB_TOPIC=$PUBSUB_BASE_NAME-topic
+$ export PUBSUB_SUBSCRIPTION=$PUBSUB_BASE_NAME-sub
+$ gcloud --project $GCP_PROJECT pubsub topics create $PUBSUB_TOPIC
+$ gcloud --project $GCP_PROJECT pubsub subscriptions create $PUBSUB_SUBSCRIPTION --topic=$PUBSUB_TOPIC
+$ gcloud --project $GCP_PROJECT pubsub topics list
+$ gcloud --project $GCP_PROJECT pubsub subscriptions list
+```
+
+```
+$ export BLOCKS_GCS_PROXY_VERSION=$(make version)
+$ curl -L --output ./blocks-gcs-proxy https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64
+$ chmod +x ./blocks-gcs-proxy
+$ ./blocks-gcs-proxy --version
+
+
+
+## Without NackOnError
+
+Start blocks-gcs-proxy with app.rb
+
+```
+$ ./blocks-gcs-proxy --config config_without_nack_on_error.json app.rb %{attrs.exit_code}
+```
+
+Send messages from another terminal.
+
+```
+$ gcloud --project $GCP_PROJECT pubsub topics publish projects/$GCP_PROJECT/topics/$PUBSUB_TOPIC --attribute exit_code=0
+$ gcloud --project $GCP_PROJECT pubsub topics publish projects/$GCP_PROJECT/topics/$PUBSUB_TOPIC --attribute exit_code=1
+```
+
+Each of the messages must show you that app.rb is called once.
+
+
+## With NackOnError
+
+Start blocks-gcs-proxy with app.rb
+
+```
+$ ./blocks-gcs-proxy --config config_with_nack_on_error.json app.rb %{attrs.exit_code}
+```
+
+Send messages from another terminal.
+
+```
+$ gcloud --project $GCP_PROJECT pubsub topics publish projects/$GCP_PROJECT/topics/$PUBSUB_TOPIC --attribute exit_code=0
+$ gcloud --project $GCP_PROJECT pubsub topics publish projects/$GCP_PROJECT/topics/$PUBSUB_TOPIC --attribute exit_code=1
+```
+
+The 2nd message must show you that app.rb is called repeatedly.

--- a/examples/error_handling/app.rb
+++ b/examples/error_handling/app.rb
@@ -1,0 +1,8 @@
+#! /usr/bin/env ruby
+
+puts ARGV.inspect
+
+code = ARGV.first.to_i
+puts "Now exiting with code: #{code}"
+
+exit code

--- a/examples/error_handling/config_with_nack_on_error.json
+++ b/examples/error_handling/config_with_nack_on_error.json
@@ -1,0 +1,6 @@
+{
+  "job": {
+    "subscription": "projects/{{ .GCP_PROJECT }}/subscriptions/{{ .PUBSUB_SUBSCRIPTION }}",
+    "nack_on_error": true
+  }
+}

--- a/examples/error_handling/config_without_nack_on_error.json
+++ b/examples/error_handling/config_without_nack_on_error.json
@@ -1,0 +1,5 @@
+{
+  "job": {
+    "subscription": "projects/{{ .GCP_PROJECT }}/subscriptions/{{ .PUBSUB_SUBSCRIPTION }}"
+  }
+}

--- a/job.go
+++ b/job.go
@@ -50,6 +50,8 @@ type Job struct {
 
 	outputBuffer *bytes.Buffer
 
+	NackOnError bool
+
 	cmd *exec.Cmd
 }
 
@@ -64,13 +66,18 @@ func (job *Job) run() error {
 	defer job.withNotify(CLEANUP, job.clearWorkspace)() // Call clearWorkspace even if job.prepare retuns error
 	err := job.withNotify(INITIALIZING, job.prepare)()
 
+	reaction := job.message.Ack
+
 	if err == nil {
 		err = job.runWithoutErrorHandling()
+		if err != nil && job.NackOnError {
+			reaction = job.message.Nack
+		}
 	}
 
 	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 	step := map[bool]JobStep{false: ACKSENDING, true: CANCELLING}[err != nil]
-	e := job.withNotify(step, job.message.Ack)()
+	e := job.withNotify(step, reaction)()
 	if e != nil {
 		return e
 	}

--- a/job.go
+++ b/job.go
@@ -60,7 +60,14 @@ const (
 
 func (job *Job) run() error {
 	job.message.raw.Message.Attributes[StartTimeKey] = time.Now().Format(time.RFC3339)
-	err := job.runWithoutErrorHandling()
+
+	defer job.withNotify(CLEANUP, job.clearWorkspace)() // Call clearWorkspace even if job.prepare retuns error
+	err := job.withNotify(INITIALIZING, job.prepare)()
+
+	if err == nil {
+		err = job.runWithoutErrorHandling()
+	}
+
 	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
 	step := map[bool]JobStep{false: ACKSENDING, true: CANCELLING}[err != nil]
 	e := job.withNotify(step, job.message.Ack)()
@@ -71,17 +78,10 @@ func (job *Job) run() error {
 }
 
 func (job *Job) runWithoutErrorHandling() error {
-	defer job.withNotify(CLEANUP, job.clearWorkspace)() // Call clearWorkspace even if setupWorkspace retuns error
-
-	err := job.withNotify(INITIALIZING, job.prepare)()
-	if err != nil {
-		return err
-	}
-
 	go job.message.sendMADPeriodically(job.notification)
 	defer job.message.Done()
 
-	err = job.withNotify(DOWNLOADING, job.downloadFiles)()
+	err := job.withNotify(DOWNLOADING, job.downloadFiles)()
 	if err != nil {
 		return err
 	}

--- a/job_subscription_config.go
+++ b/job_subscription_config.go
@@ -10,6 +10,7 @@ type JobSubscriptionConfig struct {
 	Subscription string              `json:"subscription,omitempty"`
 	PullInterval int                 `json:"pull_interval,omitempty"`
 	Sustainer    *JobSustainerConfig `json:"sustainer,omitempty"`
+	NackOnError  bool                `json:"nack_on_error,omitempty"`
 }
 
 func (c *JobSubscriptionConfig) setup() *ConfigError {

--- a/process.go
+++ b/process.go
@@ -121,6 +121,7 @@ func (p *Process) run() error {
 			message:              msg,
 			notification:         p.notification,
 			storage:              p.storage,
+			NackOnError:          p.config.Job.NackOnError,
 		}
 		job.setupExecUUID()
 		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), ConcurrentBatchJobIdKey4Log: msg.ConcurrentBatchJobId()})

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.0"
+const VERSION = "0.9.1-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.1-alpha1"
+const VERSION = "0.9.1"


### PR DESCRIPTION
Add `job.nack_on_error` option to return NACK instead of ACK on error.
See an example at https://github.com/groovenauts/blocks-gcs-proxy/compare/features/nack_on_error?expand=1#diff-2ad240ae87a8e572339135a2470770f5

Please be careful that it returns NACK repeatedly when application always returns NONE-ZERO exit code.
