### PR TITLE
Prevent duplicated job execution

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,6 +107,48 @@
   version = "v1.2.1"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/tidwall/btree"
+  packages = ["."]
+  revision = "9876f1454cf0993a53d74c27196993e345f50dd1"
+
+[[projects]]
+  name = "github.com/tidwall/buntdb"
+  packages = ["."]
+  revision = "2da7c106683f522198cdf55ed8db42b374de50d7"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/tidwall/gjson"
+  packages = ["."]
+  revision = "01f00f129617a6fe98941fb920d6c760241b54d2"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tidwall/grect"
+  packages = ["."]
+  revision = "ba9a043346eba55344e40d66a5e74cfda3a9d293"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tidwall/match"
+  packages = ["."]
+  revision = "1731857f09b1f38450e2c12409748407822dc6be"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tidwall/rtree"
+  packages = [".","base"]
+  revision = "6cd427091e0e662cb4f8e2c9eb1a41e1c46ff0d3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/tidwall/tinyqueue"
+  packages = ["."]
+  revision = "1e39f55115634cad2c504631c8bfcc292f2c9c55"
+
+[[projects]]
   name = "github.com/tinylib/msgp"
   packages = ["msgp"]
   revision = "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1"
@@ -157,6 +199,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a5765b4b8caed99d5425a57a18ede6cc9b065b782af155acd9c56caa8c1ada41"
+  inputs-digest = "45db544d901d1b9be9c63211bb1cc927c3cf317fc3142b674c37edf3eecf0931"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ specified by `job.subscription` in `config.json`.
 | job.sustainer.delay | int | False | See [Sustainer](#sustainer) | The new deadline in second to extend deadline to ack |
 | job.sustainer.disabled | bool | False | See [Sustainer](#sustainer) | Disable sustainer if it's true |
 | job.sustainer.interval | int | False | See [Sustainer](#sustainer) | The interval in second to send the message which extends deadline to ack |
+| job_check | map | False | | |
+| job_check.method | string | True | "none" | Method to check job before running. You can set one of `none` or `buntdb`  |
+| job_check.database | string | False |  | The database name to store job execution data. The usage depends on `method` |
+| job_check.bucket   | string | False |  | The bucket name to store job execution data. The usage depends on `method` |
 | progress | map | False |  |  |
 | progress.attributes | map[string]string | False | {} | Static attributes of progress notification message |
 | progress.level | string | False | `info` | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |

--- a/job_check_by_buntdb.go
+++ b/job_check_by_buntdb.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"github.com/tidwall/buntdb"
+)
+
+type JobCheckByBuntDB struct {
+	File   string
+	Prefix string
+}
+
+func (jc *JobCheckByBuntDB) Check(job *Job, f func() error) error {
+	key := jc.Prefix + job.message.ConcurrentBatchJobId()
+	err := jc.Open(func(tx *buntdb.Tx) error {
+		jobStatus, err := jc.GetStatus(tx, key)
+		if err != nil {
+			return err
+		}
+		if jobStatus != "" {
+			log.Infof("Job %q is %s. So it will be skipped.\n", key, jobStatus)
+			err := job.message.Ack()
+			if err != nil {
+				log.Warningf("Failed to send ACK to skip Job %q.\n", key)
+			}
+			return nil
+		}
+
+		err = jc.SetStatus(tx, key, "executing", log.Errorf)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = f()
+
+	return jc.Open(func(tx *buntdb.Tx) error {
+		if err != nil {
+			jc.SetStatus(tx, key, "error", log.Warningf)
+			return err
+		}
+
+		jc.SetStatus(tx, key, "completed", log.Warningf)
+		return nil
+	})
+}
+
+func (jc *JobCheckByBuntDB) Open(f func(tx *buntdb.Tx) error) error {
+	// Open the data.db file. It will be created if it doesn't exist.
+	db, err := buntdb.Open(jc.File)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	return db.Update(f)
+}
+
+func (jc *JobCheckByBuntDB) GetStatus(tx *buntdb.Tx, key string) (string, error) {
+	val, err := tx.Get(key)
+	if err == buntdb.ErrNotFound {
+		return "", nil
+	}
+	if err != nil {
+		log.Errorf("Failed to get value for %s because of %v\n", key, err)
+		return "", err
+	}
+	return val, nil
+}
+
+func (jc *JobCheckByBuntDB) SetStatus(tx *buntdb.Tx, key, value string, logMethod func(string, ...interface{})) error {
+	_, _, err := tx.Set(key, value, nil)
+	if err != nil {
+		logMethod("Failed to get value for %s because of %v\n", key, err)
+		return err
+	}
+	return nil
+}

--- a/job_check_config.go
+++ b/job_check_config.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+)
+
+type JobCheckConfig struct {
+	Method   string `json:"method"`
+	Database string `json:"database,omitempty"`
+	Bucket   string `json:"bucket,omitempty"`
+}
+
+func (c *JobCheckConfig) setup() *ConfigError {
+	c.Prepare()
+	return c.Validate()
+}
+
+func (c *JobCheckConfig) Prepare() {
+	if c.Method == "" {
+		c.Method = "none"
+	}
+	switch c.Method {
+	case JobCheckMethodNone:
+	case JobCheckMethodBuntDB:
+		if c.Database == "" {
+			c.Database = "blocks-gcs-proxy.db"
+		}
+		if c.Bucket == "" {
+			c.Bucket = "jobs:"
+		}
+	}
+}
+
+const (
+	JobCheckMethodNone   = "none"
+	JobCheckMethodBuntDB = "buntdb"
+)
+
+var JobCheckMethods = []string{
+	JobCheckMethodNone,
+	JobCheckMethodBuntDB,
+}
+
+func (c *JobCheckConfig) Validate() *ConfigError {
+	switch c.Method {
+	case JobCheckMethodNone:
+		return nil
+	case JobCheckMethodBuntDB:
+		if c.Bucket == "" {
+			return &ConfigError{Name: "bucket", Message: fmt.Sprintf("bucket is required for method %q", c.Method)}
+		}
+		return nil
+	default:
+		return &ConfigError{Name: "method", Message: fmt.Sprintf("%q is invalid. It must be one of %v", c.Method, JobCheckMethods)}
+	}
+}
+
+func (c *JobCheckConfig) Checker() func(*Job, func() error) error {
+	switch c.Method {
+	case JobCheckMethodNone:
+		return func(job *Job, f func() error) error {
+			return f()
+		}
+	case JobCheckMethodBuntDB:
+		checker := &JobCheckByBuntDB{
+			File:   c.Database,
+			Prefix: c.Bucket,
+		}
+		return checker.Check
+	default:
+		return func(job *Job, f func() error) error {
+			return &ConfigError{Name: "method", Message: fmt.Sprintf("%q is invalid. It must be one of %v", c.Method, JobCheckMethods)}
+		}
+	}
+
+}

--- a/process.go
+++ b/process.go
@@ -125,7 +125,11 @@ func (p *Process) run() error {
 			ErrorResponse:        p.config.Job.ErrorResponse,
 		}
 		job.setupExecUUID()
-		jobLog := logger.WithFields(logrus.Fields{"exec-uuid": job.execUUID, "message-id": msg.MessageId(), ConcurrentBatchJobIdKey4Log: msg.ConcurrentBatchJobId()})
+		jobLog := logger.WithFields(logrus.Fields{
+			"exec-uuid":                 job.execUUID,
+			"message-id":                msg.MessageId(),
+			ConcurrentBatchJobIdKey4Log: msg.ConcurrentBatchJobId(),
+		})
 		err := p.replaceGlobalLog(jobLog, func() error {
 			err := job.run()
 			if err != nil {

--- a/process.go
+++ b/process.go
@@ -131,7 +131,7 @@ func (p *Process) run() error {
 			ConcurrentBatchJobIdKey4Log: msg.ConcurrentBatchJobId(),
 		})
 		err := p.replaceGlobalLog(jobLog, func() error {
-			err := job.run()
+			err := p.checkJobToExecute(job, job.run)
 			if err != nil {
 				logAttrs := logrus.Fields{"error": err, "msg": msg}
 				log.WithFields(logAttrs).Fatalln("Job Error")
@@ -155,4 +155,9 @@ func (p *Process) replaceGlobalLog(newLog *logrus.Entry, f func() error) error {
 		log = logBackup
 	}()
 	return f()
+}
+
+func (p *Process) checkJobToExecute(job *Job, f func() error) error {
+	check := p.config.JobCheck.Checker()
+	return check(job, f)
 }

--- a/process_config.go
+++ b/process_config.go
@@ -13,6 +13,7 @@ type (
 	ProcessConfig struct {
 		Command  *CommandConfig              `json:"command,omitempty"`
 		Job      *JobSubscriptionConfig      `json:"job,omitempty"`
+		JobCheck *JobCheckConfig             `json:"job_check,omitempty"`
 		Progress *ProgressNotificationConfig `json:"progress,omitempty"`
 		Log      *LogConfig                  `json:"log,omitempty"`
 		Download *DownloadConfig             `json:"download"`
@@ -25,11 +26,12 @@ func (c *ProcessConfig) setup(args []string) error {
 		"command": func() *ConfigError {
 			return c.setupCommand(args)
 		},
-		"job":      c.setupJob,
-		"progress": c.setupProgress,
-		"log":      c.setupLog,
-		"download": c.setupDownload,
-		"upload":   c.setupUpload,
+		"job":       c.setupJob,
+		"job_check": c.setupJobCheck,
+		"progress":  c.setupProgress,
+		"log":       c.setupLog,
+		"download":  c.setupDownload,
+		"upload":    c.setupUpload,
 	}
 	for key, setup := range setups {
 		err := setup()
@@ -54,6 +56,13 @@ func (c *ProcessConfig) setupJob() *ConfigError {
 		c.Job = &JobSubscriptionConfig{}
 	}
 	return c.Job.setup()
+}
+
+func (c *ProcessConfig) setupJobCheck() *ConfigError {
+	if c.JobCheck == nil {
+		c.JobCheck = &JobCheckConfig{}
+	}
+	return c.JobCheck.setup()
 }
 
 func (c *ProcessConfig) setupProgress() *ConfigError {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.10.0-alpha1"
+const VERSION = "0.10.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.9.2"
+const VERSION = "0.10.0-alpha1"


### PR DESCRIPTION
Cloud pubsub guarantees at-least-once message delivery so it delivers message twice occasionally.
This PR adds a feature to prevent executing the same job twice locally by checking `concurrent_batch_job_id` in message from `blocks-concurrent-batch-agent`

## config.json

```
  "job_check": {
    "method": "buntdb"
    "database": "blocks-gcs-proxy.db",
    "bucket": "jobs:"
  }
```

`job_check` is optional. It works when `job_check.method` is `buntdb`.

[buntdb](https://github.com/tidwall/buntdb) is a small database.

## Future enhancement

The feature by this PR works with local database, it's enough to prevent the same job execution locally.
If you need to prevent the same job execution among some VMs/containers, consider implement prevention with cloud datastore or something.

