### PR TITLE
Fix job skipping

### DIFF
--- a/job_check_by_buntdb.go
+++ b/job_check_by_buntdb.go
@@ -9,8 +9,8 @@ type JobCheckByBuntDB struct {
 	Prefix string
 }
 
-func (jc *JobCheckByBuntDB) Check(job *Job, f func() error) error {
-	key := jc.Prefix + job.message.ConcurrentBatchJobId()
+func (jc *JobCheckByBuntDB) Check(job_id string, ack func() error, f func() error) error {
+	key := jc.Prefix + job_id
 	err := jc.Open(func(tx *buntdb.Tx) error {
 		jobStatus, err := jc.GetStatus(tx, key)
 		if err != nil {
@@ -18,7 +18,7 @@ func (jc *JobCheckByBuntDB) Check(job *Job, f func() error) error {
 		}
 		if jobStatus != "" {
 			log.Infof("Job %q is %s. So it will be skipped.\n", key, jobStatus)
-			err := job.message.Ack()
+			err := ack()
 			if err != nil {
 				log.Warningf("Failed to send ACK to skip Job %q.\n", key)
 			}

--- a/job_check_by_buntdb_test.go
+++ b/job_check_by_buntdb_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type JobCheckCallee struct {
+	Called bool
+}
+
+func (c *JobCheckCallee) Test() error {
+	c.Called = true
+	return nil
+}
+
+func TestJobCheckByBuntDB(t *testing.T) {
+	c := &JobCheckByBuntDB{
+		File:   "test-buntdb.db",
+		Prefix: "jobs",
+	}
+	defer os.Remove(c.File)
+
+	job_id1 := "job_id1"
+	job_id2 := "job_id2"
+
+	// 1st time
+	(func() {
+		ack := &JobCheckCallee{}
+		main := &JobCheckCallee{}
+		err := c.Check(job_id1, ack.Test, main.Test)
+		assert.NoError(t, err)
+		assert.Equal(t, false, ack.Called)
+		assert.Equal(t, true, main.Called)
+	})()
+
+	// 2nd time
+	(func() {
+		ack := &JobCheckCallee{}
+		main := &JobCheckCallee{}
+		err := c.Check(job_id1, ack.Test, main.Test)
+		assert.NoError(t, err)
+		assert.Equal(t, true, ack.Called)
+		assert.Equal(t, false, main.Called)
+	})()
+
+	// another job
+	(func() {
+		ack := &JobCheckCallee{}
+		main := &JobCheckCallee{}
+		err := c.Check(job_id2, ack.Test, main.Test)
+		assert.NoError(t, err)
+		assert.Equal(t, false, ack.Called)
+		assert.Equal(t, true, main.Called)
+	})()
+}

--- a/job_check_config.go
+++ b/job_check_config.go
@@ -55,10 +55,10 @@ func (c *JobCheckConfig) Validate() *ConfigError {
 	}
 }
 
-func (c *JobCheckConfig) Checker() func(*Job, func() error) error {
+func (c *JobCheckConfig) Checker() func(string, func() error, func() error) error {
 	switch c.Method {
 	case JobCheckMethodNone:
-		return func(job *Job, f func() error) error {
+		return func(job_id string, ack, f func() error) error {
 			return f()
 		}
 	case JobCheckMethodBuntDB:
@@ -68,7 +68,7 @@ func (c *JobCheckConfig) Checker() func(*Job, func() error) error {
 		}
 		return checker.Check
 	default:
-		return func(job *Job, f func() error) error {
+		return func(job_id string, ack, f func() error) error {
 			return &ConfigError{Name: "method", Message: fmt.Sprintf("%q is invalid. It must be one of %v", c.Method, JobCheckMethods)}
 		}
 	}

--- a/process.go
+++ b/process.go
@@ -159,5 +159,5 @@ func (p *Process) replaceGlobalLog(newLog *logrus.Entry, f func() error) error {
 
 func (p *Process) checkJobToExecute(job *Job, f func() error) error {
 	check := p.config.JobCheck.Checker()
-	return check(job, f)
+	return check(job.message.ConcurrentBatchJobId(), job.message.Ack, f)
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.10.0"
+const VERSION = "0.10.1-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.10.1-alpha1"
+const VERSION = "0.10.1"


### PR DESCRIPTION
This PR is a bug fix for the feature by #84 .
The feature could check duplicated job execution but couldn't skip processing for the job. This PR fixes such a careless mistake.

And simplify the arguments of Check method to improve testability.
