### PR TITLE
Prevent duplicated job processing with gcslock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "056a55f54a6cc77b440b31a56a5e7c3982d32811"
-  version = "v0.22.0"
+  revision = "0fd7230b2a7505833d5f69b75cbd6c9582401479"
+  version = "v0.23.0"
 
 [[projects]]
   branch = "master"
@@ -66,7 +66,7 @@
   branch = "master"
   name = "github.com/knq/pemutil"
   packages = ["."]
-  revision = "e7ebaf079fb4b0fc071be79e23c25bc41ee283e9"
+  revision = "a6a7785bc45acb2584f823861c3ad9a70e04f787"
 
 [[projects]]
   branch = "fix/error_reporting"
@@ -74,6 +74,12 @@
   packages = ["."]
   revision = "c63826842414963a8d536e33d13817e89fa23160"
   source = "https://github.com/groovenauts/sdhook.git"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/marcacohen/gcslock"
+  packages = ["."]
+  revision = "5782a95db7e207c634ebf85ca8fcd970b7a27ac5"
 
 [[projects]]
   name = "github.com/philhofer/fwd"
@@ -103,8 +109,8 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -164,31 +170,31 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "1a580b3eff7814fc9b40602fd35256c63b50f491"
+  revision = "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp"]
-  revision = "2491c5de3490fced2f6cff376127c667efeed857"
+  revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
   packages = [".","google","internal","jws","jwt"]
-  revision = "cdc340f7c179dbbfa4afd43b7614e8fcadde4269"
+  revision = "1e0a3fa8ba9a5c9eb35c271780101fdaf1b205d7"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "7c87d13f8e835d2fb3a70a2912c811ed0c1d241b"
+  revision = "bff228c7b664c5fce602223a05fb708fd8654986"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
   packages = ["clouderrorreporting/v1beta1","gensupport","googleapi","googleapi/internal/uritemplates","logging/v2beta1","pubsub/v1","storage/v1"]
-  revision = "d7aa31fbd7da4467a8056610e654315a4c1f068e"
+  revision = "ef86ce4234efee96020bde00391d6a9cfae66561"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -199,6 +205,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "45db544d901d1b9be9c63211bb1cc927c3cf317fc3142b674c37edf3eecf0931"
+  inputs-digest = "5ab1063f1e96e36f6c7929319810637dcfa71455abd07525ab50a992ae88064a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ specified by `job.subscription` in `config.json`.
 | job.sustainer.disabled | bool | False | See [Sustainer](#sustainer) | Disable sustainer if it's true |
 | job.sustainer.interval | int | False | See [Sustainer](#sustainer) | The interval in second to send the message which extends deadline to ack |
 | job_check | map | False | | |
-| job_check.method | string | True | "none" | Method to check job before running. You can set one of `none` or `buntdb`  |
+| job_check.method | string | True | "none" | Method to check job before running. You can set one of `none`, `buntdb` or `gcslock` |
 | job_check.database | string | False |  | The database name to store job execution data. The usage depends on `method` |
 | job_check.bucket   | string | False |  | The bucket name to store job execution data. The usage depends on `method` |
 | job_check.timeout  | string | False |  | The timeout expression like '1h10m10s'. The usage depends on `method` |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ specified by `job.subscription` in `config.json`.
 | job_check.method | string | True | "none" | Method to check job before running. You can set one of `none` or `buntdb`  |
 | job_check.database | string | False |  | The database name to store job execution data. The usage depends on `method` |
 | job_check.bucket   | string | False |  | The bucket name to store job execution data. The usage depends on `method` |
+| job_check.timeout  | string | False |  | The timeout expression like '1h10m10s'. The usage depends on `method` |
 | progress | map | False |  |  |
 | progress.attributes | map[string]string | False | {} | Static attributes of progress notification message |
 | progress.level | string | False | `info` | Log level to publish job progress. You can set one of `debug`, `info`, `warn`, `error`, `fatal` and `panic`. |

--- a/config-simple.json
+++ b/config-simple.json
@@ -1,8 +1,8 @@
 {
   "job":{
-    "subscription":"projects/scenic-doodad-617/subscriptions/akm-pipeline01-job-subscription"
+    "subscription":"projects/your-gcs-project/subscriptions/akm-pipeline01-job-subscription"
   },
   "progress":{
-    "topic":"projects/scenic-doodad-617/topics/akm-pipeline01-progress-topic"
+    "topic":"projects/your-gcs-project/topics/akm-pipeline01-progress-topic"
   },
 }

--- a/examples/devpub/README.md
+++ b/examples/devpub/README.md
@@ -9,11 +9,11 @@ If you have some [JSON lines](http://jsonlines.org/) files like the following on
 you can publish messages for each line of the file by using [pubsub-devpub](https://github.com/groovenauts/pubsub-devpub).
 
 ```
-{"topic":"projects/scenic-doodad-617/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000001\"]"}}
-{"topic":"projects/scenic-doodad-617/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000002\"]"}}
-{"topic":"projects/scenic-doodad-617/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000003\"]"}}
-{"topic":"projects/scenic-doodad-617/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000004\"]"}}
-{"topic":"projects/scenic-doodad-617/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000005\"]"}}
+{"topic":"projects/your-gcs-project/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000001\"]"}}
+{"topic":"projects/your-gcs-project/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000002\"]"}}
+{"topic":"projects/your-gcs-project/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000003\"]"}}
+{"topic":"projects/your-gcs-project/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000004\"]"}}
+{"topic":"projects/your-gcs-project/topics/devpub-target-topic","attributes":{"download_files":"[\"gs://akm-test/path/to/file000005\"]"}}
 (snip)
 ```
 

--- a/examples/ruby/pipeline.json.erb
+++ b/examples/ruby/pipeline.json.erb
@@ -1,6 +1,6 @@
 {
   "name":"concurrent-batch-ruby-example1",
-  "project_id":"scenic-doodad-617",
+  "project_id":"<%= ENV['GCS_PROJECT'] %>",
   "zone":"asia-east1-a",
   "boot_disk": {
     "source_image":"https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/family/cos-stable"

--- a/job.go
+++ b/job.go
@@ -105,6 +105,9 @@ const (
 )
 
 func (job *Job) run() error {
+	log.Debugln("Job.run start")
+	defer log.Debugln("Job.run done")
+
 	job.message.raw.Message.Attributes[StartTimeKey] = time.Now().Format(time.RFC3339)
 
 	defer job.withNotify(CLEANUP, job.clearWorkspace)() // Call clearWorkspace even if job.prepare retuns error
@@ -130,6 +133,9 @@ func (job *Job) run() error {
 }
 
 func (job *Job) runWithoutErrorHandling() error {
+	log.Debugln("Job.runWithoutErrorHandling start")
+	defer log.Debugln("Job.runWithoutErrorHandling done")
+
 	go job.message.sendMADPeriodically(job.notification)
 	defer job.message.Done()
 

--- a/job.go
+++ b/job.go
@@ -283,6 +283,9 @@ func (job *Job) setupDownloadFiles() error {
 	objects := job.flatten(job.remoteDownloadFiles)
 	remoteUrls := []string{}
 	for _, obj := range objects {
+		if obj == nil {
+			continue
+		}
 		switch obj.(type) {
 		case string:
 			remoteUrls = append(remoteUrls, obj.(string))

--- a/job.go
+++ b/job.go
@@ -290,7 +290,7 @@ func (job *Job) setupDownloadFiles() error {
 		case string:
 			remoteUrls = append(remoteUrls, obj.(string))
 		default:
-			log.WithFields(logrus.Fields{"url": obj}).Errorf("Invalid download file URL: %T\n", obj)
+			log.WithFields(logrus.Fields{"url": obj}).Warningf("Invalid download file URL: %T\n", obj)
 		}
 	}
 	for _, remote_url := range remoteUrls {

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -177,10 +177,8 @@ func (jc *JobCheckByGcslock) WaitAndTouch(object string, nextLimit time.Time) er
 	logger.Debugln("Updating lock file")
 	_, err := jc.Storage.Update(jc.Bucket, object, metadata)
 	if err != nil {
-		if !IsGoogleApiError(err, http.StatusNotFound) {
-			logger.Errorln("Failed to updatelock file")
-			return err
-		}
+		logger.Errorln("Failed to updatelock file")
+		return err
 	}
 	logger.Debugln("Update lock file successfully")
 	return nil

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -137,7 +137,7 @@ func (jc *JobCheckByGcslock) Unlock(m gcslock.ContextLocker) error {
 }
 
 func (jc *JobCheckByGcslock) StartTouching(object string, interval time.Duration) error {
-	logger := log.WithFields(logrus.Fields{"lock": fmt.Sprintf("gs://%s/%s", jc.Bucket, object)})
+	logger := log.WithFields(logrus.Fields{"lock": fmt.Sprintf("gs://%s/%s", jc.Bucket, object), "interval": interval})
 	logger.Infoln("JobCheckByGcslock.StartTouching Start")
 	defer logger.Infoln("JobCheckByGcslock.StartTouching Finished")
 

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	storage "google.golang.org/api/storage/v1"
+
+	"github.com/marcacohen/gcslock"
+	logrus "github.com/sirupsen/logrus"
+)
+
+type JobCheckByGcslock struct {
+	Bucket  string
+	DirPath string
+	Timeout time.Duration
+	Storage Storage
+
+	working bool
+	mux     sync.Mutex
+}
+
+func (jc *JobCheckByGcslock) Check(job_id string, _ack func() error, f func() error) error {
+	object := jc.DirPath + "/" + job_id + ".gcslock"
+
+	ctx := context.Background()
+
+	err := jc.DeleteIfTimedout(object)
+	if err != nil {
+		log.Errorf("Failed to DeleteIfTimedout gs://%s/%s because of %v\n", jc.Bucket, object, err)
+		return err
+	}
+
+	m, err := gcslock.New(ctx, jc.Bucket, object)
+	if err != nil {
+		log.Errorf("Failed to gcslock.New because of %v\n", err)
+		return err
+	}
+
+	if err := jc.Lock(ctx, m); err != nil {
+		return err
+	}
+	defer jc.Unlock(ctx, m)
+
+	go jc.StartTouching(object, time.Duration(int64(jc.Timeout)/10))
+
+	err = f()
+
+	jc.mux.Lock()
+	defer jc.mux.Unlock()
+
+	jc.working = false
+
+	return err
+}
+
+func (jc *JobCheckByGcslock) DeleteIfTimedout(object string) error {
+	f, err := jc.Storage.Get(jc.Bucket, object)
+	if err != nil {
+		if IsGoogleApiError(err, http.StatusNotFound) {
+			return nil
+		}
+		return err
+	}
+
+	ut, err := time.Parse(time.RFC3339, f.Updated)
+	if err != nil {
+		log.Errorf("Failed to parse file update time %q of %v because of %v\n", f.Updated, f, err)
+		return err
+	}
+
+	deadline := ut.Add(jc.Timeout)
+	if deadline.After(time.Now()) {
+		// deadline hasn't come yet
+		return fmt.Errorf("Deadline hasn't come yet. It seems another process is working.")
+	}
+
+	err = jc.Storage.Delete(jc.Bucket, object)
+	if err != nil {
+		if !IsGoogleApiError(err, http.StatusNotFound) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (jc *JobCheckByGcslock) Lock(c context.Context, m gcslock.ContextLocker) error {
+	ctx, cancel := context.WithTimeout(c, 1*time.Second)
+	defer cancel()
+
+	// Wait up to 1 second to acquire a lock.
+	if err := m.ContextLock(ctx); err != nil {
+		log.Errorf("Failed to ContextLock because of %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func (jc *JobCheckByGcslock) Unlock(c context.Context, m gcslock.ContextLocker) error {
+	ctx, cancel := context.WithTimeout(c, 1*time.Second)
+	defer cancel()
+
+	if err := m.ContextUnlock(ctx); err != nil {
+		log.Errorf("Failed to ContextUnlock because of %v\n", err)
+		return err
+	}
+	return nil
+}
+
+func (jc *JobCheckByGcslock) StartTouching(object string, interval time.Duration) error {
+	jc.working = true
+	for {
+		nextLimit := time.Now().Add(time.Duration(interval) * time.Second)
+		err := jc.WaitAndTouch(object, nextLimit)
+		if err != nil {
+			log.WithFields(logrus.Fields{"error": err}).Errorln("Error in StartTouching")
+			return err
+		}
+		if !jc.working {
+			return nil
+		}
+	}
+	// return nil
+}
+
+func (jc *JobCheckByGcslock) WaitAndTouch(object string, nextLimit time.Time) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	for now := range ticker.C {
+		if !jc.working {
+			ticker.Stop()
+			return nil
+		}
+		if now.After(nextLimit) {
+			ticker.Stop()
+			break
+		}
+	}
+
+	jc.mux.Lock()
+	defer jc.mux.Unlock()
+
+	logAttrs := logrus.Fields{"bucket": jc.Bucket, "object": object}
+	log.WithFields(logAttrs).Debugln("WaitAndTouch")
+
+	if !jc.working {
+		log.WithFields(logAttrs).Infoln("WaitAndTouch working is done")
+		return nil
+	}
+
+	metadata := &storage.Object{
+		Metadata: map[string]string{
+			"JobCheckByGcslock": time.Now().Format(time.RFC3339),
+		},
+	}
+	_, err := jc.Storage.Update(jc.Bucket, object, metadata)
+	if err != nil {
+		if IsGoogleApiError(err, http.StatusNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -174,18 +174,18 @@ func (jc *JobCheckByGcslock) WaitAndTouch(object string, nextLimit time.Time) er
 		return nil
 	}
 
-	metadata := &storage.Object{
-		Metadata: map[string]string{
-			"JobCheckByGcslock": time.Now().Format(time.RFC3339),
-		},
+	metadata := map[string]string{
+		"JobCheckByGcslock": time.Now().Format(time.RFC3339),
 	}
+	msg := &storage.Object{Metadata: metadata}
 
-	logger.Debugln("Updating lock file")
-	_, err := jc.Storage.Update(jc.Bucket, object, metadata)
+	logger = logger.WithFields(logrus.Fields{"metadata": metadata})
+	logger.Debugln("WaitAndTouch Update lock file starting")
+	_, err := jc.Storage.Update(jc.Bucket, object, msg)
 	if err != nil {
-		logger.Errorln("Failed to updatelock file")
+		logger.Errorf("WaitAndTouch Update lock file error because of %v\n", err)
 		return err
 	}
-	logger.Debugln("Update lock file successfully")
+	logger.Debugln("WaitAndTouch Update lock file success")
 	return nil
 }

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -51,12 +51,13 @@ func (jc *JobCheckByGcslock) Check(job_id string, _ack func() error, f func() er
 		return err
 	}
 	defer jc.Unlock(m, func() error {
+		logger.Debugf("Deleting lock file instead of unlock starting.\n")
 		err = jc.Storage.Delete(jc.Bucket, object)
 		if err != nil {
-			logger.Warningf("Deleting exceeded lock file instead of unlock error.\n")
+			logger.Warningf("Deleting lock file instead of unlock error.\n")
 			return err
 		}
-		logger.Infof("Deleting exceeded lock file instead of unlock success.\n")
+		logger.Infof("Deleting lock file instead of unlock success.\n")
 		return nil
 	})
 

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -108,8 +108,11 @@ func (jc *JobCheckByGcslock) DeleteIfTimedout(object string) (bool, error) {
 func (jc *JobCheckByGcslock) Lock(m gcslock.ContextLocker) error {
 	log.Debugln("JobCheckByGcslock.Lock start")
 
-	// Wait up to 1 second to acquire a lock.
-	if err := m.ContextLock(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Wait up to 10 seconds to acquire a lock.
+	if err := m.ContextLock(ctx); err != nil {
 		log.Errorf("Failed to ContextLock because of %v\n", err)
 		return err
 	}
@@ -121,7 +124,10 @@ func (jc *JobCheckByGcslock) Lock(m gcslock.ContextLocker) error {
 func (jc *JobCheckByGcslock) Unlock(m gcslock.ContextLocker) error {
 	log.Debugln("JobCheckByGcslock.Unlock start")
 
-	if err := m.ContextUnlock(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := m.ContextUnlock(ctx); err != nil {
 		log.Errorf("Failed to ContextUnlock because of %v\n", err)
 		return err
 	}

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -89,9 +89,7 @@ func (jc *JobCheckByGcslock) DeleteIfTimedout(object string) error {
 	return nil
 }
 
-func (jc *JobCheckByGcslock) Lock(c context.Context, m gcslock.ContextLocker) error {
-	ctx, cancel := context.WithTimeout(c, 1*time.Second)
-	defer cancel()
+func (jc *JobCheckByGcslock) Lock(ctx context.Context, m gcslock.ContextLocker) error {
 
 	// Wait up to 1 second to acquire a lock.
 	if err := m.ContextLock(ctx); err != nil {
@@ -102,10 +100,7 @@ func (jc *JobCheckByGcslock) Lock(c context.Context, m gcslock.ContextLocker) er
 	return nil
 }
 
-func (jc *JobCheckByGcslock) Unlock(c context.Context, m gcslock.ContextLocker) error {
-	ctx, cancel := context.WithTimeout(c, 1*time.Second)
-	defer cancel()
-
+func (jc *JobCheckByGcslock) Unlock(ctx context.Context, m gcslock.ContextLocker) error {
 	if err := m.ContextUnlock(ctx); err != nil {
 		log.Errorf("Failed to ContextUnlock because of %v\n", err)
 		return err

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -143,7 +143,7 @@ func (jc *JobCheckByGcslock) StartTouching(object string, interval time.Duration
 
 	jc.working = true
 	for {
-		nextLimit := time.Now().Add(time.Duration(interval) * time.Second)
+		nextLimit := time.Now().Add(interval)
 		err := jc.WaitAndTouch(object, nextLimit)
 		if err != nil {
 			log.WithFields(logrus.Fields{"error": err}).Errorln("Error in StartTouching")

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -29,6 +29,7 @@ func (jc *JobCheckByGcslock) Check(job_id string, _ack func() error, f func() er
 
 	logger := log.WithFields(logrus.Fields{"lock": url})
 	logger.Infoln("JobCheckByGcslock Start")
+	defer logger.Infoln("JobCheckByGcslock done")
 
 	ok, err := jc.DeleteIfTimedout(object)
 	if err != nil {
@@ -53,8 +54,8 @@ func (jc *JobCheckByGcslock) Check(job_id string, _ack func() error, f func() er
 
 	go jc.StartTouching(object, time.Duration(int64(jc.Timeout)/10))
 
-	logger.Infoln("JobCheckByGcslock passed")
-	defer logger.Infoln("JobCheckByGcslock done")
+	logger.Debugln("JobCheckByGcslock handler starting")
+	defer logger.Debugln("JobCheckByGcslock handler done")
 
 	err = f()
 

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -71,10 +71,11 @@ func (jc *JobCheckByGcslock) DeleteIfTimedout(object string) error {
 
 	f, err := jc.Storage.Get(jc.Bucket, object)
 	if err != nil {
-		if IsGoogleApiError(err, http.StatusNotFound) {
-			return nil
-		}
 		return err
+	}
+	// Ok unless the file exists
+	if f == nil {
+		return nil
 	}
 
 	ut, err := time.Parse(time.RFC3339, f.Updated)
@@ -92,10 +93,6 @@ func (jc *JobCheckByGcslock) DeleteIfTimedout(object string) error {
 	logger.Debugln("Deleting exceeded lock file")
 	err = jc.Storage.Delete(jc.Bucket, object)
 	if err != nil {
-		if !IsGoogleApiError(err, http.StatusNotFound) {
-			logger.Debugln("Failed to delete exceeded lock file")
-			return err
-		}
 	}
 	logger.Debugln("Delete exceeded lock file successfully")
 

--- a/job_check_config.go
+++ b/job_check_config.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"fmt"
+	"time"
 )
 
 type JobCheckConfig struct {
 	Method   string `json:"method"`
 	Database string `json:"database,omitempty"`
 	Bucket   string `json:"bucket,omitempty"`
+	Timeout  string `json:"timeout,omitempty"`
+
+	storage Storage
 }
 
 func (c *JobCheckConfig) setup() *ConfigError {
@@ -28,17 +32,26 @@ func (c *JobCheckConfig) Prepare() {
 		if c.Bucket == "" {
 			c.Bucket = "jobs:"
 		}
+	case JobCheckMethodGcslock:
+		if c.Database == "" {
+			c.Database = "gcslocks"
+		}
+		if c.Timeout == "" {
+			c.Timeout = "6h"
+		}
 	}
 }
 
 const (
-	JobCheckMethodNone   = "none"
-	JobCheckMethodBuntDB = "buntdb"
+	JobCheckMethodNone    = "none"
+	JobCheckMethodBuntDB  = "buntdb"
+	JobCheckMethodGcslock = "gcslock"
 )
 
 var JobCheckMethods = []string{
 	JobCheckMethodNone,
 	JobCheckMethodBuntDB,
+	JobCheckMethodGcslock,
 }
 
 func (c *JobCheckConfig) Validate() *ConfigError {
@@ -48,6 +61,15 @@ func (c *JobCheckConfig) Validate() *ConfigError {
 	case JobCheckMethodBuntDB:
 		if c.Bucket == "" {
 			return &ConfigError{Name: "bucket", Message: fmt.Sprintf("bucket is required for method %q", c.Method)}
+		}
+		return nil
+	case JobCheckMethodGcslock:
+		if c.Bucket == "" {
+			return &ConfigError{Name: "bucket", Message: fmt.Sprintf("bucket is required for method %q", c.Method)}
+		}
+		_, err := time.ParseDuration(c.Timeout)
+		if err != nil {
+			return &ConfigError{Name: "timeout", Message: fmt.Sprintf("Invalid timeout %q", c.Timeout)}
 		}
 		return nil
 	default:
@@ -67,10 +89,23 @@ func (c *JobCheckConfig) Checker() func(string, func() error, func() error) erro
 			Prefix: c.Bucket,
 		}
 		return checker.Check
+	case JobCheckMethodGcslock:
+		d, err := time.ParseDuration(c.Timeout)
+		if err != nil {
+			return func(job_id string, ack, f func() error) error {
+				return &ConfigError{Name: "timeout", Message: fmt.Sprintf("Invalid timeout %q", c.Timeout)}
+			}
+		}
+		checker := &JobCheckByGcslock{
+			Bucket:  c.Bucket,
+			DirPath: c.Database,
+			Timeout: d,
+			Storage: c.storage,
+		}
+		return checker.Check
 	default:
 		return func(job_id string, ack, f func() error) error {
 			return &ConfigError{Name: "method", Message: fmt.Sprintf("%q is invalid. It must be one of %v", c.Method, JobCheckMethods)}
 		}
 	}
-
 }

--- a/job_check_config.go
+++ b/job_check_config.go
@@ -37,7 +37,7 @@ func (c *JobCheckConfig) Prepare() {
 			c.Database = "gcslocks"
 		}
 		if c.Timeout == "" {
-			c.Timeout = "6h"
+			c.Timeout = "10m"
 		}
 	}
 }

--- a/job_message.go
+++ b/job_message.go
@@ -122,7 +122,7 @@ func (m *JobMessage) Ack() error {
 	}
 
 	logAttrs["status"] = m.status
-	log.WithFields(logAttrs).Debugln("Updating status to acked")
+	log.WithFields(logAttrs).Infoln("Updating status to acked")
 
 	m.status = acked
 	return nil
@@ -144,7 +144,7 @@ func (m *JobMessage) Nack() error {
 	}
 
 	logAttrs["status"] = m.status
-	log.WithFields(logAttrs).Debugln("Updating status to done")
+	log.WithFields(logAttrs).Infoln("Updating status to done")
 
 	m.status = done
 	return nil
@@ -166,7 +166,7 @@ func (m *JobMessage) sendMADPeriodically(notification *ProgressNotification) err
 	if m.config.Disabled {
 		return nil
 	}
-	log.Printf("sendMADPeriodically start\n")
+	log.Infof("sendMADPeriodically start\n")
 	for {
 		nextLimit := time.Now().Add(time.Duration(m.config.Interval) * time.Second)
 		err := m.waitAndSendMAD(notification, nextLimit)
@@ -175,7 +175,7 @@ func (m *JobMessage) sendMADPeriodically(notification *ProgressNotification) err
 			return err
 		}
 		if !m.running() {
-			log.Debugln("sendMADPeriodically return")
+			log.Infof("sendMADPeriodically stopped\n")
 			return nil
 		}
 	}

--- a/job_message.go
+++ b/job_message.go
@@ -111,18 +111,18 @@ func (m *JobMessage) Ack() error {
 	defer m.mux.Unlock()
 
 	logAttrs := logrus.Fields{"job_message_id": m.MessageId(), "ack_id": m.raw.AckId}
-	log.WithFields(logAttrs).Debugln("Sending ACK")
+	log.WithFields(logAttrs).Debugln("JobMessage.Ack starting")
 
 	_, err := m.puller.Acknowledge(m.sub, m.raw.AckId)
 	if err != nil {
 		logAttrs["raw"] = fmt.Sprintf("%v", m.raw)
 		logAttrs["error"] = err
-		log.WithFields(logAttrs).Errorln("Failed to acknowledge")
+		log.WithFields(logAttrs).Errorln("JobMessage.Ack error")
 		return err
 	}
 
 	logAttrs["status"] = m.status
-	log.WithFields(logAttrs).Infoln("Updating status to acked")
+	log.WithFields(logAttrs).Infoln("JobMessage.Ack success")
 
 	m.status = acked
 	return nil
@@ -133,18 +133,18 @@ func (m *JobMessage) Nack() error {
 	defer m.mux.Unlock()
 
 	logAttrs := logrus.Fields{"job_message_id": m.MessageId(), "ack_id": m.raw.AckId}
-	log.WithFields(logAttrs).Debugln("Sending NACK")
+	log.WithFields(logAttrs).Debugln("JobMessage.Nack")
 
 	_, err := m.puller.ModifyAckDeadline(m.sub, []string{m.raw.AckId}, 0)
 	if err != nil {
 		logAttrs["raw"] = fmt.Sprintf("%v", m.raw)
 		logAttrs["error"] = err
-		log.WithFields(logAttrs).Errorln("Failed to send ModifyAckDeadline as a NACK")
+		log.WithFields(logAttrs).Errorln("JobMessage.Nack error")
 		return err
 	}
 
 	logAttrs["status"] = m.status
-	log.WithFields(logAttrs).Infoln("Updating status to done")
+	log.WithFields(logAttrs).Infoln("JobMessage.Nack success")
 
 	m.status = done
 	return nil
@@ -152,7 +152,7 @@ func (m *JobMessage) Nack() error {
 
 func (m *JobMessage) Done() {
 	logAttrs := logrus.Fields{"job_message_id": m.MessageId(), "status": m.status}
-	log.WithFields(logAttrs).Debugln("Done()")
+	log.WithFields(logAttrs).Debugln("JobMessage.Done")
 	if m.status == running {
 		m.status = done
 	}

--- a/job_subscription.go
+++ b/job_subscription.go
@@ -34,7 +34,9 @@ func (s *JobSubscription) process(f func(*JobMessage) error) (bool, error) {
 		return false, nil
 	}
 
-	log.WithFields(logrus.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message}).Infoln("Message received")
+	logger := log.WithFields(logrus.Fields{"job_message_id": msg.Message.MessageId, "message": msg.Message})
+	logger.Infoln("Message received")
+	defer logger.Infoln("Message processed")
 
 	jobMsg := &JobMessage{
 		sub:    s.config.Subscription,

--- a/process.go
+++ b/process.go
@@ -56,6 +56,7 @@ func (p *Process) setup() error {
 		service:          storageService.Objects,
 		ContentTypeByExt: p.config.Upload.ContentTypeByExt,
 	}
+	p.config.JobCheck.storage = p.storage
 
 	// Creates a pubsubService
 	pubsubService, err := pubsub.New(client)

--- a/storage.go
+++ b/storage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"mime"
+	"net/http"
 	"os"
 	"path"
 

--- a/storage.go
+++ b/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 
+	"google.golang.org/api/googleapi"
 	storage "google.golang.org/api/storage/v1"
 
 	logrus "github.com/sirupsen/logrus"
@@ -15,6 +16,9 @@ type (
 	Storage interface {
 		Download(bucket, object, destPath string) error
 		Upload(bucket, object, srcPath string) error
+		Get(bucket, object string) (*storage.Object, error)
+		Delete(bucket, object string) error
+		Update(bucket, object string, body *storage.Object) (*storage.Object, error)
 	}
 
 	CloudStorage struct {
@@ -68,4 +72,49 @@ func (ct *CloudStorage) Upload(bucket, object, srcPath string) error {
 	}
 	log.WithFields(logAttrs).Debugln("Upload successfully")
 	return nil
+}
+
+func (ct *CloudStorage) Get(bucket, object string) (*storage.Object, error) {
+	log := log.WithFields(logrus.Fields{"url": "gs://" + bucket + "/" + object})
+	log.Debugln("Getting file info")
+	obj, err := ct.service.Get(bucket, object).Do()
+	if err != nil {
+		log.WithFields(logrus.Fields{"error": err}).Errorf("Failed to get GCS file info")
+		return nil, err
+	}
+	return obj, err
+}
+
+func (ct *CloudStorage) Delete(bucket, object string) error {
+	log := log.WithFields(logrus.Fields{"url": "gs://" + bucket + "/" + object})
+	log.Debugln("Deleting file")
+	err := ct.service.Delete(bucket, object).Do()
+	if err != nil {
+		log.WithFields(logrus.Fields{"error": err}).Errorf("Failed to delete GCS file")
+		return err
+	}
+	return err
+}
+
+func (ct *CloudStorage) Update(bucket, object string, body *storage.Object) (*storage.Object, error) {
+	log := log.WithFields(logrus.Fields{"url": "gs://" + bucket + "/" + object})
+	log.Debugln("Updating file")
+	obj, err := ct.service.Update(bucket, object, body).Do()
+	if err != nil {
+		log.WithFields(logrus.Fields{"error": err}).Errorf("Failed to update GCS file")
+		return nil, err
+	}
+	return obj, nil
+}
+
+func IsGoogleApiError(err error, code int) bool {
+	if err != nil {
+		apiErr, ok := err.(*googleapi.Error)
+		if ok {
+			if apiErr.Code == code {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha3"
+const VERSION = "0.11.0-alpha4"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha4"
+const VERSION = "0.11.0-alpha5"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha5"
+const VERSION = "0.11.0-alpha6"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha7"
+const VERSION = "0.11.0-alpha8"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha8"
+const VERSION = "0.11.0-alpha9"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha10"
+const VERSION = "0.11.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha6"
+const VERSION = "0.11.0-alpha7"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha2"
+const VERSION = "0.11.0-alpha3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha1"
+const VERSION = "0.11.0-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.10.1"
+const VERSION = "0.11.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0-alpha9"
+const VERSION = "0.11.0-alpha10"


### PR DESCRIPTION
Use https://github.com/marcacohen/gcslock to lock from https://github.com/groovenauts/blocks-gcs-proxy/pull/84#issuecomment-392707055 .

Cloud pubsub sometimes publishes a message again before the ack is returned for [At-Least-Once Delivery](https://cloud.google.com/pubsub/docs/subscriber#at-least-once-delivery) .
So this PR adds a feature to prevent processing the same message in such cases.
