### PR TITLE
Update libraries and add an example

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -205,6 +205,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5ab1063f1e96e36f6c7929319810637dcfa71455abd07525ab50a992ae88064a"
+  inputs-digest = "9385b6e010eb76a0a02138c92ec068b082af245bb7d1e846ce8b94895aa4562c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -127,8 +127,8 @@
 [[projects]]
   name = "github.com/tidwall/gjson"
   packages = ["."]
-  revision = "01f00f129617a6fe98941fb920d6c760241b54d2"
-  version = "v1.1.0"
+  revision = "afaeb9562041a8018c74e006551143666aed08bf"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
@@ -170,7 +170,7 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
-  revision = "8ac0e0d97ce45cd83d1d7243c060cb8461dda5e9"
+  revision = "027cca12c2d63e3d62b670d901e8a2c95854feec"
 
 [[projects]]
   branch = "master"
@@ -188,19 +188,19 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "bff228c7b664c5fce602223a05fb708fd8654986"
+  revision = "6c888cc515d3ed83fc103cf1d84468aad274b0a7"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/api"
   packages = ["clouderrorreporting/v1beta1","gensupport","googleapi","googleapi/internal/uritemplates","logging/v2beta1","pubsub/v1","storage/v1"]
-  revision = "ef86ce4234efee96020bde00391d6a9cfae66561"
+  revision = "2eea9ba0a3d94f6ab46508083e299a00bbbc65f6"
 
 [[projects]]
   name = "google.golang.org/appengine"
   packages = [".","internal","internal/app_identity","internal/base","internal/datastore","internal/log","internal/modules","internal/remote_api","internal/urlfetch","urlfetch"]
-  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
-  version = "v1.0.0"
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/examples/ruby/.gitignore
+++ b/examples/ruby/.gitignore
@@ -1,3 +1,4 @@
 /Dockerfile
 /tmp
 /pipeline.json
+/.env

--- a/examples/sleep/.gitignore
+++ b/examples/sleep/.gitignore
@@ -1,3 +1,4 @@
 /tmp
 /Dockerfile
 /pipeline.json
+/.env

--- a/examples/sleep/.gitignore
+++ b/examples/sleep/.gitignore
@@ -1,0 +1,3 @@
+/tmp
+/Dockerfile
+/pipeline.json

--- a/examples/sleep/Dockerfile.erb
+++ b/examples/sleep/Dockerfile.erb
@@ -1,0 +1,20 @@
+# [config] IMAGE_NAME: "groovenauts/concurrent_batch_sleep_example"
+# [config]
+# [config] WORKING_DIR: "."
+# [config] VERSION_SCRIPT: 'grep VERSION ../../version.go | cut -f2 -d\"'
+# [config] GIT_TAG_PREFIX: 'examples/sleep/'
+
+FROM ruby:2.4-jessie
+
+ENV APP_HOME /usr/app/batch_type_example
+COPY . $APP_HOME
+WORKDIR $APP_HOME
+
+ENV BLOCKS_GCS_PROXY_VERSION <%= require './version'; GCS_PROXY_VERSION %>
+RUN mkdir -p /usr/app && \
+    curl -L --output ${APP_HOME}/blocks-gcs-proxy \
+         https://github.com/groovenauts/blocks-gcs-proxy/releases/download/v${BLOCKS_GCS_PROXY_VERSION}/blocks-gcs-proxy_linux_amd64 && \
+    chmod +x ${APP_HOME}/blocks-gcs-proxy && \
+    ./blocks-gcs-proxy --version
+
+CMD ["./blocks-gcs-proxy", "-c", "./config.json", "sleep", "%{attrs.sleep_time}"]

--- a/examples/sleep/Makefile
+++ b/examples/sleep/Makefile
@@ -1,0 +1,9 @@
+generate:
+	erb Dockerfile.erb > Dockerfile
+	erb pipeline.json.erb > pipeline.json
+
+build: generate
+	brocket build
+
+release:
+	brocket release

--- a/examples/sleep/README.md
+++ b/examples/sleep/README.md
@@ -1,0 +1,16 @@
+# blocks-gcs-proxy sleep example
+
+## Setup
+
+```
+cd path/to/blocks-gcs-proxy/examples/sleep
+source ../../.env
+make generate
+make release
+
+curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -X POST http://$AEHOST/orgs/$ORG_ID/pipelines --data @pipeline.json
+curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' http://$AEHOST/orgs/$ORG_ID/pipelines
+
+export PIPELINE_ID=xxxxxx
+curl -v -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -X POST "http://$AEHOST/pipelines/$PIPELINE_ID/jobs?ready=true" --data '{"message": {"attributes": {"sleep_time": "60"}}}'
+```

--- a/examples/sleep/config.json
+++ b/examples/sleep/config.json
@@ -1,0 +1,10 @@
+{
+  "job_check": {
+    "method": "gcslock",
+    "bucket": "{{ .GCSLOCK_BUCKET }}"
+  },
+  "log": {
+    "level": "debug",
+    "command_severity": "debug"
+  }
+}

--- a/examples/sleep/job.json
+++ b/examples/sleep/job.json
@@ -1,0 +1,5 @@
+{
+  "attributes": {
+    "sleep_time": 60
+  }
+}

--- a/examples/sleep/pipeline.json.erb
+++ b/examples/sleep/pipeline.json.erb
@@ -1,0 +1,19 @@
+{
+  "name":"concurrent-batch-sleep-example1",
+  "project_id":"<%= ENV['GCS_PROJECT'] %>",
+  "zone":"asia-east1-a",
+  "boot_disk": {
+    "source_image":"https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/family/cos-stable"
+  },
+  "machine_type":"f1-micro",
+  "target_size":1,
+  "container_size":1,
+  "container_name":"groovenauts/concurrent_batch_sleep_example:<%= require './version'; GCS_PROXY_VERSION %>",
+  "token_consumption": 1,
+  "hibernation_delay": 180,
+  "job_scaler": {
+    "enabled": true,
+    "max_instance_size": 3
+  },
+  "docker_run_options": "--restart=on-failure:5 -e GCSLOCK_BUCKET=<%= ENV['GCSLOCK_BUCKET'] %>"
+}

--- a/examples/sleep/version.rb
+++ b/examples/sleep/version.rb
@@ -1,0 +1,2 @@
+path = File.expand_path('../../../version.go', __FILE__)
+GCS_PROXY_VERSION = File.read(path).scan(/\"(.+)\"/).flatten.first

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.0"
+const VERSION = "0.11.1"


### PR DESCRIPTION
#86 might have some dirty changes because the inputs-digest was changed in #86 but it wasn't committed. 
So this PR commits it as https://github.com/groovenauts/blocks-gcs-proxy/pull/88/commits/f143545643a26e88d4f9004e308ef2cfebcc307d .

## Other changes

- Update library versions
- Add examples/sleep
