### PR TITLE
Allow irregular URL to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ specified by `job.subscription` in `config.json`.
 | command.dryrun | bool | False | `false` | Don't run the command if this is true. |
 | command.options | map[key][]string | False |  | Define if you have to run one of multiple command. See [Multiple command options](#multiple-command-options) for more detail. |
 | download                  | map | False |  |  |
+| download.allow_irregular_url | bool | False | False | Allow not strict URL to download |
 | download.worker           | map | False |  |  |
 | download.worker.max_tries | int | False | 0 | The number of tries to download. |
 | download.worker.workers   | int | False | 1 | The number of thread to download. |

--- a/download_config.go
+++ b/download_config.go
@@ -1,7 +1,8 @@
 package main
 
 type DownloadConfig struct {
-	Worker *WorkerConfig `json:"worker,omitempty"`
+	Worker            *WorkerConfig `json:"worker,omitempty"`
+	AllowIrregularUrl bool          `json:"allow_irregular_url,omitempty"`
 }
 
 func (c *DownloadConfig) setup() *ConfigError {

--- a/job.go
+++ b/job.go
@@ -300,7 +300,7 @@ func (job *Job) setupDownloadFiles() error {
 		}
 	}
 	for _, remote_url := range remoteUrls {
-		url, err := url.Parse(remote_url)
+		url, err := job.parseUrl(remote_url)
 		if err != nil {
 			log.WithFields(logrus.Fields{"url": remote_url}).Errorln("Invalid download file URL")
 			return err
@@ -449,7 +449,7 @@ func (job *Job) convertError(src error) error {
 func (job *Job) downloadFiles() error {
 	targets := []*Target{}
 	for remoteURL, destPath := range job.downloadFileMap {
-		url, err := url.Parse(remoteURL)
+		url, err := job.parseUrl(remoteURL)
 		if err != nil {
 			log.WithFields(logrus.Fields{"url": remoteURL, "error": err}).Errorln("Invalid URL")
 			return err
@@ -600,4 +600,14 @@ func (job *Job) flatten(obj interface{}) []interface{} {
 	default:
 		return []interface{}{obj}
 	}
+}
+
+func (job *Job) parseUrl(s string) (*url.URL, error) {
+	var f func(string) (*url.URL, error)
+	if job.downloadConfig != nil && job.downloadConfig.AllowIrregularUrl {
+		f = urlParse
+	} else {
+		f = url.Parse
+	}
+	return f(s)
 }

--- a/url.go
+++ b/url.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/url"
+	"regexp"
+)
+
+var SubUrlPattern = regexp.MustCompile(`\A(.+)://([^\/]+)(.*)\z`)
+
+func urlParse(s string) (*url.URL, error) {
+	r, err := url.Parse(s)
+	if err == nil {
+		return r, nil
+	}
+	parts := SubUrlPattern.FindStringSubmatch(s)
+	if len(parts) < 4 {
+		return nil, err
+	}
+	return &url.URL{
+		Scheme: parts[1],
+		Host:   parts[2],
+		Path:   parts[3],
+	}, nil
+}

--- a/url_test.go
+++ b/url_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUrlParse(t *testing.T) {
+	(func() {
+		s := "gs://bucket0/path/to/file0"
+		r, err := url.Parse(s)
+		assert.NoError(t, err)
+		assert.Equal(t, "gs", r.Scheme)
+		assert.Equal(t, "bucket0", r.Host)
+		assert.Equal(t, "/path/to/file0", r.Path)
+
+		r2, err := urlParse(s)
+		assert.NoError(t, err)
+		assert.Equal(t, "gs", r2.Scheme)
+		assert.Equal(t, "bucket0", r2.Host)
+		assert.Equal(t, "/path/to/file0", r2.Path)
+
+		assert.Equal(t, r, r2)
+	})()
+
+	(func() {
+		s := "gs://bucket0/path%/to/file0"
+		_, err := url.Parse(s)
+		assert.Error(t, err)
+
+		r2, err := urlParse(s)
+		assert.NoError(t, err)
+		assert.Equal(t, "gs", r2.Scheme)
+		assert.Equal(t, "bucket0", r2.Host)
+		assert.Equal(t, "/path%/to/file0", r2.Path)
+	})()
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.11.1"
+const VERSION = "0.12.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.12.0-alpha1"
+const VERSION = "0.12.0"


### PR DESCRIPTION
Google Cloud Storage accepts irregular characters as URL like `%` . 
So this PR has `blocks-gcs-proxy` try parsing URL again with a regular expression `(scheme)://(host)(path)` on error from `url.Parse` with `download.allow_irregular_url` of `config.json`.
