### PR TITLE
Use complete file

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"mime"
 	"net/http"
@@ -133,7 +134,8 @@ func IsGoogleApiError(err error, code int) bool {
 func (ct *CloudStorage) CreateEmptyFile(bucket, object string) (*storage.Object, error) {
 	logAttrs := logrus.Fields{"url": "gs://" + bucket + "/" + object}
 	obj := &storage.Object{Name: object, ContentType: "text/plain"}
-	res, err := ct.service.Insert(bucket, obj).Do()
+	buf := bytes.NewBufferString("")
+	res, err := ct.service.Insert(bucket, obj).Media(buf).Do()
 	if err != nil {
 		logAttrs["error"] = err
 		log.WithFields(logAttrs).Warnf("Failed to create empty file")

--- a/storage.go
+++ b/storage.go
@@ -20,6 +20,7 @@ type (
 		Get(bucket, object string) (*storage.Object, error)
 		Delete(bucket, object string) error
 		Update(bucket, object string, body *storage.Object) (*storage.Object, error)
+		CreateEmptyFile(bucket, object string) (*storage.Object, error)
 	}
 
 	CloudStorage struct {
@@ -127,4 +128,17 @@ func IsGoogleApiError(err error, code int) bool {
 		}
 	}
 	return false
+}
+
+func (ct *CloudStorage) CreateEmptyFile(bucket, object string) (*storage.Object, error) {
+	logAttrs := logrus.Fields{"url": "gs://" + bucket + "/" + object}
+	obj := &storage.Object{Name: object, ContentType: "text/plain"}
+	res, err := ct.service.Insert(bucket, obj).Do()
+	if err != nil {
+		logAttrs["error"] = err
+		log.WithFields(logAttrs).Warnf("Failed to create empty file")
+		return nil, err
+	}
+	log.WithFields(logAttrs).Debugln("Upload successfully")
+	return res, nil
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.12.0"
+const VERSION = "0.13.0-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.13.0-alpha1"
+const VERSION = "0.13.0-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.13.0-alpha2"
+const VERSION = "0.13.0"


### PR DESCRIPTION
Cloud pub/sub sometimes delivers messages after it is acknowledged.
To prevent duplicated job processing, create complete file for each job in GCS after job finished.
And check complete file before start processing.

