### PR TITLE
Send Ack to avoid duplicated running

### DIFF
--- a/job.go
+++ b/job.go
@@ -124,7 +124,12 @@ func (job *Job) run() error {
 	}
 
 	job.message.raw.Message.Attributes[FinishTimeKey] = time.Now().Format(time.RFC3339)
-	step := map[bool]JobStep{false: ACKSENDING, true: CANCELLING}[err != nil]
+	var step JobStep
+	if err != nil {
+		step = CANCELLING
+	} else {
+		step = ACKSENDING
+	}
 	e := job.withNotify(step, reaction)()
 	if e != nil {
 		return e

--- a/job_check_by_gcslock.go
+++ b/job_check_by_gcslock.go
@@ -49,7 +49,7 @@ func (jc *JobCheckByGcslock) Check(job_id string, ack func() error, f func() err
 
 	if err := jc.Lock(m); err != nil {
 		if err2 := ack(); err2 != nil {
-			log.Errorf("Failed to Ack for getting lock failure because of %v\n", err2)
+			log.Errorf("Failed to Ack for quitting for getting lock failure because of %v\n", err2)
 		}
 		return err
 	}
@@ -72,6 +72,9 @@ func (jc *JobCheckByGcslock) Check(job_id string, ack func() error, f func() err
 	}
 	if completeObj != nil {
 		log.Warningf("Quit running job which is completed because %s already exists\n", completePath)
+		if err := ack(); err != nil {
+			log.Errorf("Failed to Ack for quitting for job completion because of %v\n", err)
+		}
 		return nil
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.13.0"
+const VERSION = "0.13.1-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.13.1-alpha1"
+const VERSION = "0.13.1-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.13.1-alpha2"
+const VERSION = "0.13.1"


### PR DESCRIPTION
Send ACK when gcslock file or complete file already exists.

Before, messages which don't get ack is deliver again and again,
so lots of message stagnate and they interfere other job processing and make response slow.

@guemon Thanks you for the great help!